### PR TITLE
Support EdgeGrid environment variables.

### DIFF
--- a/akamai/provider.go
+++ b/akamai/provider.go
@@ -61,7 +61,7 @@ func getConfigDNSV1Service(d *schema.ResourceData) (*edgegrid.Config, error) {
 	edgerc := d.Get("edgerc").(string)
 	section := d.Get("fastdns_section").(string)
 
-	fastDnsConfig, err := edgegrid.InitEdgeRc(edgerc, section)
+	fastDnsConfig, err := edgegrid.Init(edgerc, section)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func getPAPIV1Service(d *schema.ResourceData) (*edgegrid.Config, error) {
 	edgerc := d.Get("edgerc").(string)
 	section := d.Get("papi_section").(string)
 
-	papiConfig, err := edgegrid.InitEdgeRc(edgerc, section)
+	papiConfig, err := edgegrid.Init(edgerc, section)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Let's the provider work with PAPI credentials set using environment variables. This is already supported by the edgegrid client. The provider just needs to be updated to use the right init function.