### PR TITLE
Add Content Provider Code (CP Code) Resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,22 @@ provider "akamai" {
 
 ## Resources
 
-The Akamai provider adds two resources, `akamai_fastdns_zone` and `akamai_property`.
+The Akamai provider adds three resources, `akamai_cp_code`, `akamai_fastdns_zone` and `akamai_property`.
+
+### akamai_cp_code
+
+This resource is used to configure Akamai Content Provider Codes.
+
+```hcl
+resource "akamai_cp_code" "example" {
+  contract_id = "ctr_XXX"
+  group_id    = "grp_XXX"
+  name        = "example-XXX"
+  product_id  = "prd_XXX"
+}
+```
+
+A more complete example configuration can be found [here](https://github.com/akamai/terraform-provider-akamai/blob/master/examples/akamai_cp_code/cp-code-example.tf).
 
 ### akamai_fastdns_zone
 

--- a/akamai/provider.go
+++ b/akamai/provider.go
@@ -34,6 +34,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"akamai_cp_code":      resourceCPCode(),
 			"akamai_fastdns_zone": resourceFastDNSZone(),
 			"akamai_property":     resourceProperty(),
 		},

--- a/akamai/resource_akamai_cp_code.go
+++ b/akamai/resource_akamai_cp_code.go
@@ -1,0 +1,114 @@
+package akamai
+
+import (
+	"errors"
+	"log"
+
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/papi-v1"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// PAPI CP Code
+//
+// https://developer.akamai.com/api/luna/papi/data.html#cpcode
+// https://developer.akamai.com/api/luna/papi/resources.html#cpcodesapi
+func resourceCPCode() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCPCodeCreate,
+		Read:   resourceCPCodeRead,
+		Update: resourceCPCodeUpdate,
+		Delete: resourceCPCodeDelete,
+		Exists: resourceCPCodeExists,
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"contract_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"group_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"product_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceCPCodeCreate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Creating CP Code")
+
+	cpCode := resourceCPCodePAPINewCPCodes(d, meta).NewCpCode()
+	cpCode.ProductID = d.Get("product_id").(string)
+	cpCode.CpcodeName = d.Get("name").(string)
+	err := cpCode.Save()
+	if err != nil {
+		return err
+	}
+
+	d.SetId(cpCode.CpcodeID)
+
+	log.Printf("[DEBUG] Created CP Code: +%v", cpCode)
+	return nil
+}
+
+func resourceCPCodeDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Deleting CP Code")
+
+	// No PAPI CP Code delete operation exists.
+	// https://developer.akamai.com/api/luna/papi/resources.html#cpcodesapi
+	return errors.New("deleting CP Codes is unsupported")
+}
+
+func resourceCPCodeExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	log.Printf("[DEBUG] Finding CP Code")
+
+	cpCodeName := d.Get("name").(string)
+	cpCode, err := resourceCPCodePAPINewCPCodes(d, meta).FindCpCode(cpCodeName)
+	if err != nil {
+		return false, err
+	}
+
+	log.Printf("[DEBUG] Found CP Code: %+v", cpCode)
+	return cpCode != nil, nil
+}
+
+func resourceCPCodeRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Reading CP Code")
+
+	cpCode := resourceCPCodePAPINewCPCodes(d, meta).NewCpCode()
+	cpCode.CpcodeID = d.Id()
+	err := cpCode.GetCpCode()
+	if err != nil {
+		return err
+	}
+
+	d.Set("name", cpCode.CpcodeName)
+	d.Set("product_id", cpCode.ProductIDs[0])
+
+	log.Printf("[DEBUG] Read CP Code: %+v", cpCode)
+	return nil
+}
+
+func resourceCPCodeUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Updating CP Code")
+
+	// No PAPI CP Code update operation exists.
+	// https://developer.akamai.com/api/luna/papi/resources.html#cpcodesapi
+	return errors.New("updating CP Codes is unsupported")
+}
+
+func resourceCPCodePAPINewCPCodes(d *schema.ResourceData, meta interface{}) *papi.CpCodes {
+	contract := &papi.Contract{
+		ContractID: d.Get("contract_id").(string),
+	}
+	group := &papi.Group{
+		GroupID: d.Get("group_id").(string),
+	}
+	return papi.NewCpCodes(contract, group)
+}

--- a/akamai/resource_akamai_property_create.go
+++ b/akamai/resource_akamai_property_create.go
@@ -37,6 +37,11 @@ func resourcePropertyCreate(d *schema.ResourceData, meta interface{}) error {
 		return e
 	}
 
+	cpCode, e := getCPCode(d, contract, group)
+	if e != nil {
+		return e
+	}
+
 	product, e := getProduct(d, contract)
 	if e != nil {
 		return e
@@ -83,11 +88,6 @@ func resourcePropertyCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetPartial("product_id")
 	d.SetPartial("clone_from")
 	d.SetPartial("network")
-
-	cpCode, e := createCpCode(property.Contract, property.Group, product, d)
-	if e != nil {
-		return e
-	}
 	d.SetPartial("cp_code")
 
 	rules, e := property.GetRules()

--- a/akamai/resource_akamai_property_update.go
+++ b/akamai/resource_akamai_property_update.go
@@ -32,7 +32,7 @@ func resourcePropertyUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	var cpCode *papi.CpCode
 	if d.HasChange("cp_code") {
-		cpCode, e = createCpCode(property.Contract, property.Group, product, d)
+		cpCode, e = getCPCode(d, property.Contract, property.Group)
 		if e != nil {
 			return e
 		}

--- a/examples/akamai_cp_code/cp-code-example.tf
+++ b/examples/akamai_cp_code/cp-code-example.tf
@@ -1,0 +1,19 @@
+provider "akamai" {
+  edgerc = "~/.edgerc"
+  papi_section = "default"
+}
+
+resource "akamai_cp_code" "example" {
+  contract_id = "ctr_XXX"
+  group_id    = "grp_XXX"
+  name        = "example-XXX"
+  product_id  = "prd_XXX"
+}
+
+resource "akamai_property" "example" {
+  cp_code = "${akamai_cp_code.example.id}"
+
+  // ...
+  // configure additional property fields
+  // ...
+}


### PR DESCRIPTION
This adds a new Content Provider Code resource that can be used to create them independently from property resources. The new CP code resource can likely replace the implicit resource property calls to the [createCpCode](https://github.com/akamai/terraform-provider-akamai/blob/master/akamai/resource_akamai_property_helpers.go#L144) helper.