### PR TITLE
Make account ID a computed field

### DIFF
--- a/akamai/resource_akamai_property_create.go
+++ b/akamai/resource_akamai_property_create.go
@@ -76,13 +76,13 @@ func resourcePropertyCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
+	d.Set("account_id", property.AccountID)
 	d.Set("version", property.LatestVersion)
 
 	// The API now has data, so save the partial state
 	d.SetId(property.PropertyID)
 	d.SetPartial("name")
 	d.SetPartial("rule_format")
-	d.SetPartial("account_id")
 	d.SetPartial("contract_id")
 	d.SetPartial("group_id")
 	d.SetPartial("product_id")

--- a/akamai/resource_akamai_property_schema.go
+++ b/akamai/resource_akamai_property_schema.go
@@ -57,7 +57,7 @@ var akpsBehavior = &schema.Schema{
 var akamaiPropertySchema = map[string]*schema.Schema{
 	"account_id": &schema.Schema{
 		Type:     schema.TypeString,
-		Required: true,
+		Computed: true,
 	},
 	"contract_id": &schema.Schema{
 		Type:     schema.TypeString,


### PR DESCRIPTION
A property's account ID is only returned on GET requests. As a result, it should not be a required resource field.

see:
https://developer.akamai.com/api/luna/papi/data.html#property
https://developer.akamai.com/api/luna/papi/resources.html#postpropertyversions