### PR TITLE
Force new CP code resource on certain field changes

### DIFF
--- a/akamai/resource_akamai_cp_code.go
+++ b/akamai/resource_akamai_cp_code.go
@@ -27,14 +27,17 @@ func resourceCPCode() *schema.Resource {
 			"contract_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"group_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"product_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 		},
 	}


### PR DESCRIPTION
Similar change to #39 that requires a new resource to be created on the following fields.

* contract ID
* group ID
* product ID

FYI a CP code can be renamed using Luna but this doesn't appear to be possible using PAPI. Any ideas?