### PR TITLE
Update README build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,23 +130,26 @@ A more complete example configuration can be found [here](https://github.com/aka
 Building The Provider
 ---------------------
 
+Clone source to `$GOPATH`.
+
 ```sh
 $ mkdir -p $GOPATH/src/github.com/akamai
 $ cd $GOPATH/src/github.com/akamai
 $ git clone git@github.com:akamai/terraform-provider-akamai
 ```
 
-Enter the provider directory and build the provider
+Change to source directory, install vendor dependencies, and build provider.
 
 ```sh
 $ cd $GOPATH/src/github.com/akamai/terraform-provider-akamai
+$ make dep-install
 $ make build
 ```
 
 Developing the Provider
----------------------------
+-----------------------
 
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.8+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
+If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.9+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
 
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 


### PR DESCRIPTION
Update README with latest build instructions with minimum Go 1.9 version and installing vendor dependencies using `dep` make target. Fixes issue #12.