### PR TITLE
Add property resource read function

### DIFF
--- a/akamai/resource_akamai_property_read.go
+++ b/akamai/resource_akamai_property_read.go
@@ -17,5 +17,32 @@ func resourcePropertyExists(d *schema.ResourceData, meta interface{}) (bool, err
 }
 
 func resourcePropertyRead(d *schema.ResourceData, meta interface{}) error {
+	property := papi.NewProperty(papi.NewProperties())
+	property.PropertyID = d.Id()
+	err := property.GetProperty()
+	if err != nil {
+		return err
+	}
+
+	// Cannot set clone_from. Not provided on GET requests.
+	// d.Set("clone_from", nil)
+
+	// Cannot set product_id. Not provided on GET requests.
+	// d.Set("product_id", property.ProductID)
+
+	d.Set("account_id", property.AccountID)
+	d.Set("contract_id", property.ContractID)
+	d.Set("group_id", property.GroupID)
+	d.Set("name", property.PropertyName)
+	d.Set("note", property.Note)
+	d.Set("rule_format", property.RuleFormat)
+	d.Set("version", property.LatestVersion)
+	if property.StagingVersion > 0 {
+		d.Set("staging_version", property.StagingVersion)
+	}
+	if property.ProductionVersion > 0 {
+		d.Set("production_version", property.ProductionVersion)
+	}
+
 	return nil
 }

--- a/akamai/resource_akamai_property_schema.go
+++ b/akamai/resource_akamai_property_schema.go
@@ -97,6 +97,14 @@ var akamaiPropertySchema = map[string]*schema.Schema{
 		Type:     schema.TypeInt,
 		Computed: true,
 	},
+	"staging_version": &schema.Schema{
+		Type:     schema.TypeInt,
+		Computed: true,
+	},
+	"production_version": &schema.Schema{
+		Type:     schema.TypeInt,
+		Computed: true,
+	},
 	"rule_format": &schema.Schema{
 		Type:     schema.TypeString,
 		Optional: true,


### PR DESCRIPTION
Basic property read function and computed staging/production version fields. Note, the read function is partially incomplete because it does not support reading existing behaviors/rules nor fill in specifics like CP codes, hostnames/edge hostnames, origin, network activation, etc. FWIW, these same deficiencies also exist on the import function.