### PR TITLE
Fix module name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: go
-go_import_path: github.com/akava-io/terraform-provider-akamai
 go:
 - 1.9.x
 - 1.10.x
+- 1.11.x
+- 1.12.x
 
-install:
-- make dep-install
+env:
+  global:
+    GOFLAGS=-mod=vendor
 
 script:
 - make build
-- make check
 - make test

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -38,20 +38,6 @@ lint:
 test-compile:
 	go test -c ./akamai $(TESTARGS)
 
-dep:
-	@which dep > /dev/null; if [ $$? -ne 0 ]; then \
-		echo "==> Installing dep..."; \
-		go get -u github.com/golang/dep/cmd/dep; \
-	fi
-
-dep-install: dep
-	@echo "==> Installing vendor dependencies..."
-	@dep ensure -vendor-only
-
-dep-update: dep
-	@echo "==> Updating vendor dependencies..."
-	@dep ensure -update
-
 website:
 ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 	echo "$(WEBSITE_REPO) not found in your GOPATH (necessary for layouts and assets), get-ting..."

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/akamai/terraform-provider-akamai
+module github.com/terraform-providers/terraform-provider-akamai
 
 require (
 	github.com/agext/levenshtein v0.0.0-20170217063020-5f10fee96522


### PR DESCRIPTION
The go modules setup is still broken even after this patch, specifically due to:
- incorrect checksum of go-getter - most likely result of an old buggy Go version used to vendor these dependencies in the past, and
- https://github.com/akamai/AkamaiOPEN-edgegrid-golang/pull/48

but this patch fixes at least 1 one of the existing problems - others can be fixed in separate PRs. 😉