### PR TITLE
Split apart properties and edge hostnames completely, removing any magic around hostname <-> edge hostname links.

### DIFF
--- a/akamai/resource_akamai_edge_hostname.go
+++ b/akamai/resource_akamai_edge_hostname.go
@@ -6,16 +6,13 @@ import (
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/papi-v1"
 	"github.com/hashicorp/terraform/helper/schema"
 	"log"
-	"strconv"
 	"strings"
-	"time"
 )
 
 func resourceSecureEdgeHostName() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceSecureEdgeHostNameCreate,
 		Read:   resourceSecureEdgeHostNameRead,
-		Update: resourceSecureEdgeHostNameUpdate,
 		Delete: resourceSecureEdgeHostNameDelete,
 		Exists: resourceSecureEdgeHostNameExists,
 		Importer: &schema.ResourceImporter{
@@ -29,41 +26,43 @@ var akamaiSecureEdgeHostNameSchema = map[string]*schema.Schema{
 	"product": {
 		Type:     schema.TypeString,
 		Required: true,
+		ForceNew: true,
 	},
 	"contract": {
 		Type:     schema.TypeString,
 		Required: true,
+		ForceNew: true,
 	},
 	"group": {
 		Type:     schema.TypeString,
 		Required: true,
+		ForceNew: true,
 	},
 	"edge_hostname": {
 		Type:     schema.TypeString,
 		Required: true,
+		ForceNew: true,
+	},
+	"ipv4": {
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  true,
+		ForceNew: true,
 	},
 	"ipv6": {
 		Type:     schema.TypeBool,
-		Required: true,
+		Optional: true,
+		Default:  false,
+		ForceNew: true,
 	},
-	"certenrollmentid": {
+	"ip_behavior": {
+		Type:     schema.TypeString,
+		Computed: true,
+	},
+	"certificate": {
 		Type:     schema.TypeInt,
 		Optional: true,
-	},
-	"slotnumber": {
-		Type:     schema.TypeInt,
-		Optional: true,
-		Default:  180,
-	},
-	"lehid": {
-		Type:        schema.TypeString,
-		Computed:    true,
-		Description: "List Edge Host Name",
-	},
-	"hostnames": {
-		Type:        schema.TypeMap,
-		Computed:    true,
-		Description: "List Edge Host Map",
+		ForceNew: true,
 	},
 }
 
@@ -74,20 +73,17 @@ func resourceSecureEdgeHostNameCreate(d *schema.ResourceData, meta interface{}) 
 	if e != nil {
 		return e
 	}
-	log.Println("[DEBUG] Figuring out edgehostnames GROUP = ", group)
+	log.Println("[DEBUG] Edgehostnames GROUP = ", group)
 	contract, e := getContract(d)
 	if e != nil {
 		return e
 	}
-	log.Println("[DEBUG] Figuring out edgehostnames CONTRACT = ", contract)
+	log.Println("[DEBUG] Edgehostnames CONTRACT = ", contract)
+
 	product, e := getProduct(d, contract)
 	if e != nil {
 		return e
 	}
-
-	property := papi.NewProperty(papi.NewProperties())
-	property.Group = group
-	property.Contract = contract
 
 	if group == nil {
 		return errors.New("group must be specified to create a new Edge Hostname")
@@ -100,80 +96,76 @@ func resourceSecureEdgeHostNameCreate(d *schema.ResourceData, meta interface{}) 
 	if product == nil {
 		return errors.New("product must be specified to create a new Edge Hostname")
 	}
-	// The API now has data, so save the partial state
 
-	d.SetPartial("name")
-	d.SetPartial("contract")
-	d.SetPartial("group")
-	d.SetPartial("product")
-
-	log.Println("[DEBUG] createHostnamesExt START")
-
-	hostnameEdgeHostnameMap, err := createHostnamesExt(property, product, d)
+	edgeHostnames, err := papi.GetEdgeHostnames(contract, group, "")
 	if err != nil {
 		return err
 	}
 
-	log.Println("[DEBUG] setEdgeHostnames START ", hostnameEdgeHostnameMap)
+	edgeHostname := d.Get("edge_hostname").(string)
 
-	for _, eHn := range hostnameEdgeHostnameMap {
-		log.Println("[DEBUG] Figuring out foundEdgeHostname " + eHn.EdgeHostnameDomain)
-		log.Println("[DEBUG] Figuring out foundEdgeHostname " + eHn.EdgeHostnameID)
+	ehn := edgeHostnames.NewEdgeHostname()
+	ehn.ProductID = product.ProductID
+	ehn.EdgeHostnameDomain = edgeHostname
 
-		edgehostmap := make(map[string]string)
-		for k, t := range hostnameEdgeHostnameMap {
-			var DomainPrefix string
-			var DomainSuffix string
-
-			if strings.Contains(t.EdgeHostnameDomain, ".edgesuite.net") {
-				DomainPrefix = strings.Replace(t.EdgeHostnameDomain, ".edgesuite.net", "", -1)
-				DomainSuffix = "edgesuite.net"
-				edgehostmap[t.EdgeHostnameID+"-cnameto"] = t.EdgeHostnameDomain
-				edgehostmap[t.EdgeHostnameID+"-cnamefrom"] = DomainPrefix
-				log.Println("[DEBUG] Figuring out DomainPrefix ", DomainPrefix)
-				log.Println("[DEBUG] Figuring out DomainPrefix ", DomainSuffix)
-			}
-
-			if strings.Contains(t.EdgeHostnameDomain, ".edgekey.net") {
-				DomainPrefix = strings.Replace(t.EdgeHostnameDomain, ".edgekey.net", "", -1)
-				DomainSuffix = "edgekey.net"
-				edgehostmap[t.EdgeHostnameID+"-cnameto"] = t.EdgeHostnameDomain
-				edgehostmap[t.EdgeHostnameID+"-cnamefrom"] = DomainPrefix
-				log.Println("[DEBUG] Figuring out DomainPrefix ", DomainPrefix)
-				log.Println("[DEBUG] Figuring out DomainPrefix ", DomainSuffix)
-			}
-
-			edgehostmap[t.EdgeHostnameID+"-DomainPrefix"] = DomainPrefix
-			edgehostmap[t.EdgeHostnameID+"-DomainSuffix"] = DomainSuffix
-			edgehostmap[t.EdgeHostnameID+"-edgeHostnameId"] = t.EdgeHostnameID
-			edgehostmap[t.EdgeHostnameID+"-edgeHostnameDomain"] = t.EdgeHostnameDomain
-			edgehostmap[t.EdgeHostnameID+"-ipVersionBehavior"] = t.IPVersionBehavior
-			edgehostmap[t.EdgeHostnameID+"-cnametype"] = "EDGE_HOSTNAME"
-
-			if t.Secure {
-				edgehostmap[t.EdgeHostnameID+"-secure"] = "true"
-			} else {
-				edgehostmap[t.EdgeHostnameID+"-secure"] = "false"
-			}
-
-			certenrollmentid, ok := d.GetOk("certenrollmentid")
-			if ok {
-				edgehostmap[t.EdgeHostnameID+"-certenrollmentid"] = strconv.Itoa(certenrollmentid.(int))
-			}
-
-			log.Println("[DEBUG] Figuring out MAP LOOP ", k, t)
-		}
-		log.Println("[DEBUG] Figuring out MAP ", edgehostmap)
-
-		d.Set("hostnames", edgehostmap)
-		d.Set("edgehostnamedomain", eHn.EdgeHostnameDomain)
-		d.Set("id", eHn.EdgeHostnameID)
-		d.Set("lehid", eHn.EdgeHostnameID)
-
-		d.SetId(eHn.EdgeHostnameID)
+	switch {
+	case strings.HasSuffix(edgeHostname, ".edgesuite.net"):
+		ehn.DomainPrefix = strings.TrimSuffix(edgeHostname, ".edgesuite.net")
+		ehn.DomainSuffix = "edgesuite.net"
+		ehn.SecureNetwork = "STANDARD_TLS"
+	case strings.HasSuffix(edgeHostname, ".edgekey.net"):
+		ehn.DomainPrefix = strings.TrimSuffix(edgeHostname, ".edgekey.net")
+		ehn.DomainSuffix = "edgekey.net"
+		ehn.SecureNetwork = "ENHANCED_TLS"
+	case strings.HasSuffix(edgeHostname, ".akamized.net"):
+		ehn.DomainPrefix = strings.TrimSuffix(edgeHostname, ".akamized.net")
+		ehn.DomainSuffix = "akamized.net"
+		ehn.SecureNetwork = "SHARED_CERT"
 	}
 
+	ipv4 := d.Get("ipv4").(bool)
+	if ipv4 {
+		ehn.IPVersionBehavior = "IPv4"
+	}
+
+	ipv6 := d.Get("ipv6").(bool)
+	if ipv6 {
+		ehn.IPVersionBehavior = "IPV6"
+	}
+
+	if ipv4 && ipv6 {
+		ehn.IPVersionBehavior = "IPV6_COMPLIANCE"
+	}
+
+	d.Set("ip_behavior", ehn.IPVersionBehavior)
+
+	if certEnrollmentId, ok := d.GetOk("certificate"); ok {
+		ehn.CertEnrollmentId = certEnrollmentId.(int)
+	} else if ehn.SecureNetwork == "ENHANCED_TLS" {
+		return errors.New("A certificate enrollment ID is required for Enhanced TLS (edgekey.net) edge hostnames")
+	}
+
+	if ehnFound, err := edgeHostnames.FindEdgeHostname(ehn); ehnFound != nil && ehnFound.EdgeHostnameID != "" {
+		if ehnFound.IPVersionBehavior != ehn.IPVersionBehavior {
+			return fmt.Errorf("existing edge hostname found with different IP version (%s vs %s)", ehnFound.IPVersionBehavior, ehn.IPVersionBehavior)
+		}
+
+		if ehnFound.SecureNetwork != ehn.SecureNetwork {
+			return fmt.Errorf("existing edge hostname found on different network (%s vs %s)", ehnFound.SecureNetwork, ehn.SecureNetwork)
+		}
+
+		log.Println("[DEBUG] Existing edge hostname FOUND = ", ehnFound.EdgeHostnameID)
+	} else {
+		log.Printf("[DEBUG] Creating new edge hostname: %#v\n\n", ehn)
+		err = ehn.Save("")
+		if err != nil {
+			return err
+		}
+	}
+
+	d.SetId(ehn.EdgeHostnameID)
 	d.Partial(false)
+
 	log.Println("[DEBUG] Done")
 	return nil
 }
@@ -307,256 +299,4 @@ func resourceSecureEdgeHostNameRead(d *schema.ResourceData, meta interface{}) er
 	d.SetId(edgeHostnameID)
 
 	return nil
-}
-
-func createHostnamesExt(property *papi.Property, product *papi.Product, d *schema.ResourceData) (map[string]*papi.EdgeHostname, error) {
-	// If the property has edge hostnames and none is specified in the schema, then don't update them
-	log.Println("[DEBUG] Figuring out hostnames START")
-
-	var defaultEdgeHostname *papi.EdgeHostname
-
-	edgeHostname, edgeHostnameOk := d.GetOk("edge_hostname")
-
-	certenrollmentid, ok := d.GetOk("certenrollmentid")
-	if ok {
-		log.Println("[DEBUG] Certenrollmentid for secure  ", certenrollmentid)
-	}
-
-	slotnumber, ok := d.GetOk("slotnumber")
-	if ok {
-		log.Println("[DEBUG] Slotnumber for secure  ", slotnumber)
-	}
-
-	log.Println("[DEBUG] Figuring out edgehostname ", edgeHostname)
-
-	hostname := strings.Replace(edgeHostname.(string), ".edgesuite.net", "", -1)
-	log.Println("[DEBUG] Figuring out edgehostname ", hostname)
-	hostname = strings.Replace(edgeHostname.(string), ".edgekey.net", "", -1)
-	log.Println("[DEBUG] Figuring out edgehostname ", hostname)
-	hostnames := make([]string, 0, 1)
-	hostnames = append(hostnames, hostname)
-
-	ipv6 := d.Get("ipv6").(bool)
-
-	log.Println("[DEBUG] Figuring out edgehostnames ", hostnames)
-	edgeHostnames := papi.NewEdgeHostnames()
-	log.Println("[DEBUG] NewEdgeHostnames empty struct  ", edgeHostnames.ContractID)
-	err := edgeHostnames.GetEdgeHostnames(property.Contract, property.Group, "")
-	if err != nil {
-		return nil, err
-	}
-	log.Println("[DEBUG] Edgehostnames exist in contract ")
-
-	hostnameEdgeHostnameMap := map[string]*papi.EdgeHostname{}
-
-	if len(edgeHostnames.EdgeHostnames.Items) > 0 {
-		log.Println("[DEBUG] Edgehostnames Default host ", edgeHostnames.EdgeHostnames.Items[0])
-		defaultEdgeHostname = edgeHostnames.EdgeHostnames.Items[0]
-	} else {
-		defaultEdgeHostname = nil
-	}
-
-	if edgeHostnameOk {
-		foundEdgeHostname := false
-		for _, eHn := range edgeHostnames.EdgeHostnames.Items {
-
-			if eHn.EdgeHostnameDomain == edgeHostname.(string) {
-				foundEdgeHostname = true
-				defaultEdgeHostname = eHn
-			}
-		}
-		log.Println("[DEBUG] Found EdgeHostname ", foundEdgeHostname)
-		log.Println("[DEBUG] Default EdgeHostname ", defaultEdgeHostname)
-
-		if foundEdgeHostname == false {
-			var err error
-			log.Println("[DEBUG] Found EdgeHostname FALSE create a new one " + edgeHostname.(string))
-			defaultEdgeHostname, err = createSecureEdgehostname(edgeHostnames, product, edgeHostname.(string), ipv6, certenrollmentid.(int), slotnumber.(int))
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		for _, hostname := range hostnames {
-			if _, ok := hostnameEdgeHostnameMap[hostname]; !ok {
-				hostnameEdgeHostnameMap[hostname] = defaultEdgeHostname
-				return hostnameEdgeHostnameMap, nil
-			}
-		}
-
-	}
-
-	// Contract/Group has _some_ Edge Hostnames, try to map 1:1 (e.g. example.com -> example.com.edgesuite.net)
-	// If some mapping exists, map non-existent ones to the first 1:1 we find, otherwise if none exist map to the
-	// first Edge Hostname found in the contract/group
-	if len(edgeHostnames.EdgeHostnames.Items) > 0 {
-		log.Println("[DEBUG] Hostnames retrieved, trying to map")
-		edgeHostnamesMap := map[string]*papi.EdgeHostname{}
-
-		for _, edgeHostname := range edgeHostnames.EdgeHostnames.Items {
-			edgeHostnamesMap[edgeHostname.EdgeHostnameDomain] = edgeHostname
-		}
-
-		// Search for existing hostname, map 1:1
-		var overrideDefault bool
-		for _, hostname := range hostnames {
-
-			if edgeHostname, ok := edgeHostnamesMap[hostname+".edgesuite.net"]; ok {
-
-				hostnameEdgeHostnameMap[hostname] = edgeHostname
-				// Override the default with the first one found
-				if !overrideDefault {
-					defaultEdgeHostname = edgeHostname
-					overrideDefault = true
-				}
-				continue
-			}
-			if edgeHostname, ok := edgeHostnamesMap[hostname+".edgekey.net"]; ok {
-
-				hostnameEdgeHostnameMap[hostname] = edgeHostname
-				// Override the default with the first one found
-				if !overrideDefault {
-					defaultEdgeHostname = edgeHostname
-					overrideDefault = true
-				}
-				continue
-			}
-
-		}
-
-		// Fill in defaults
-		if len(hostnameEdgeHostnameMap) < len(hostnames) {
-			log.Printf("[DEBUG] Hostnames being set to default: %d of %d\n", len(hostnameEdgeHostnameMap), len(hostnames))
-			for _, hostname := range hostnames {
-
-				if _, ok := hostnameEdgeHostnameMap[hostname]; !ok {
-
-					hostnameEdgeHostnameMap[hostname] = defaultEdgeHostname
-				}
-			}
-		}
-	}
-
-	// Contract/Group has no Edge Hostnames, create a single based on the first hostname
-	// mapping example.com -> example.com.edgegrid.net
-
-	if len(edgeHostnames.EdgeHostnames.Items) == 0 {
-		log.Println("[DEBUG] No Edge Hostnames found, creating new one", edgeHostnames)
-		newEdgeHostname, err := createSecureEdgehostname(edgeHostnames, product, hostnames[0], ipv6, certenrollmentid.(int), slotnumber.(int))
-		if err != nil {
-			return nil, err
-		}
-
-		for _, hostname := range hostnames {
-			hostnameEdgeHostnameMap[hostname] = newEdgeHostname
-		}
-
-		log.Printf("[DEBUG] Edgehostname created: %s\n", newEdgeHostname.EdgeHostnameDomain)
-	}
-
-	return hostnameEdgeHostnameMap, nil
-}
-
-func resourceSecureEdgeHostNameUpdate(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] UPDATING")
-	d.Partial(true)
-	group, e := getGroup(d)
-	if e != nil {
-		return e
-	}
-
-	contract, e := getContract(d)
-	if e != nil {
-		return e
-	}
-
-	product, e := getProduct(d, contract)
-	if e != nil {
-		return e
-	}
-
-	property := papi.NewProperty(papi.NewProperties())
-	property.Group = group
-	property.Contract = contract
-
-	if group == nil {
-		return errors.New("group must be specified to create a new Edge Hostname")
-	}
-
-	if contract == nil {
-		return errors.New("contract must be specified to create a new Edge Hostname")
-	}
-
-	if product == nil {
-		return errors.New("product must be specified to create a new Edge Hostname")
-	}
-	// The API now has data, so save the partial state
-
-	d.SetPartial("name")
-	d.SetPartial("contract")
-	d.SetPartial("group")
-	d.SetPartial("product")
-
-	if d.HasChange("hostname") || d.HasChange("ipv6") {
-		hostnameEdgeHostnameMap, err := createHostnames(property, product, d)
-		if err != nil {
-			return err
-		}
-
-		edgeHostnames, err := setEdgeHostnames(property, hostnameEdgeHostnameMap, d)
-		if err != nil {
-			return err
-		}
-		d.SetPartial("hostname")
-		d.SetPartial("ipv6")
-		d.Set("edge_hostname", edgeHostnames)
-	}
-
-	d.Partial(false)
-
-	log.Println("[DEBUG] Done")
-	return nil
-}
-
-func createSecureEdgehostname(edgeHostnames *papi.EdgeHostnames, product *papi.Product, hostname string, ipv6 bool, certenrollmentid int, slotnumber int) (*papi.EdgeHostname, error) {
-	newEdgeHostname := papi.NewEdgeHostname(edgeHostnames)
-	newEdgeHostname.ProductID = product.ProductID
-	newEdgeHostname.IPVersionBehavior = "IPV4"
-	if ipv6 {
-		newEdgeHostname.IPVersionBehavior = "IPV6_COMPLIANCE"
-	}
-	if strings.Contains(hostname, "edgekey.net") {
-		log.Println("[DEBUG] Add certificate Enrollment ID ", certenrollmentid)
-		newEdgeHostname.CertEnrollmentId = certenrollmentid
-		newEdgeHostname.SlotNumber = slotnumber
-	}
-	newEdgeHostname.EdgeHostnameDomain = hostname
-	log.Printf("[DEBUG] Edgehostname create: %s\n", newEdgeHostname.EdgeHostnameDomain)
-	if strings.Contains(newEdgeHostname.EdgeHostnameDomain, ".edgesuite.net") {
-		newEdgeHostname.DomainPrefix = strings.Replace(newEdgeHostname.EdgeHostnameDomain, ".edgesuite.net", "", -1)
-		newEdgeHostname.DomainSuffix = "edgesuite.net"
-	}
-	if strings.Contains(newEdgeHostname.EdgeHostnameDomain, ".edgekey.net") {
-		newEdgeHostname.DomainPrefix = strings.Replace(newEdgeHostname.EdgeHostnameDomain, ".edgekey.net", "", -1)
-		newEdgeHostname.DomainSuffix = "edgekey.net"
-	}
-
-	log.Printf("[DEBUG] Edgehostname create: %s\n", newEdgeHostname.DomainPrefix)
-	log.Printf("[DEBUG] Edgehostname create: %s\n", newEdgeHostname.DomainSuffix)
-	err := newEdgeHostname.Save("")
-	if err != nil {
-		return nil, err
-	}
-
-	go newEdgeHostname.PollStatus("")
-
-	for newEdgeHostname.Status != "CREATED" {
-		select {
-		case <-newEdgeHostname.StatusChange:
-		case <-time.After(time.Minute * 20):
-			return nil, fmt.Errorf("no edge hostname found and a timeout occurred trying to create \"%s.%s\"", newEdgeHostname.DomainPrefix, newEdgeHostname.DomainSuffix)
-		}
-	}
-
-	return newEdgeHostname, nil
 }

--- a/examples/akamai_property/property-json/merge.sh
+++ b/examples/akamai_property/property-json/merge.sh
@@ -1,3 +1,0 @@
-#! /bin/bash
-akamai property-manager merge -p $1
-jq -n --arg result "$1" '{"result":"'$1'"}'

--- a/examples/akamai_property/property-json/rules.json
+++ b/examples/akamai_property/property-json/rules.json
@@ -1,0 +1,383 @@
+{
+  "rules": {
+    "name": "default",
+    "children": [
+      {
+        "name": "Performance",
+        "children": [
+          {
+            "name": "JPEG Images",
+            "children": [],
+            "behaviors": [
+              {
+                "name": "adaptiveImageCompression",
+                "options": {
+                  "compressMobile": true,
+                  "compressStandard": true,
+                  "tier1StandardCompressionMethod": "BYPASS",
+                  "tier2StandardCompressionMethod": "BYPASS",
+                  "tier3StandardCompressionMethod": "COMPRESS",
+                  "tier3StandardCompressionValue": 40,
+                  "tier1MobileCompressionMethod": "BYPASS",
+                  "tier2MobileCompressionMethod": "COMPRESS",
+                  "tier2MobileCompressionValue": 60,
+                  "tier3MobileCompressionMethod": "COMPRESS",
+                  "tier3MobileCompressionValue": 40,
+                  "title_aic_mobile": "",
+                  "title_aic_nonmobile": ""
+                }
+              }
+            ],
+            "criteria": [
+              {
+                "name": "fileExtension",
+                "options": {
+                  "matchCaseSensitive": false,
+                  "matchOperator": "IS_ONE_OF",
+                  "values": [
+                    "jpg",
+                    "jpeg",
+                    "jpe",
+                    "jif",
+                    "jfif",
+                    "jfi"
+                  ]
+                }
+              }
+            ],
+            "criteriaMustSatisfy": "all",
+            "comments": "Improves load time by applying Adaptive Image Compression (AIC) to all JPEG images. The poorer the connection quality, the more AIC compresses the image files."
+          },
+          {
+            "name": "Compressible Objects",
+            "children": [],
+            "behaviors": [
+              {
+                "name": "gzipResponse",
+                "options": {
+                  "behavior": "ALWAYS"
+                }
+              }
+            ],
+            "criteria": [
+              {
+                "name": "contentType",
+                "options": {
+                  "matchCaseSensitive": false,
+                  "matchOperator": "IS_ONE_OF",
+                  "matchWildcard": true,
+                  "values": [
+                    "text/*",
+                    "application/javascript",
+                    "application/x-javascript",
+                    "application/x-javascript*",
+                    "application/json",
+                    "application/x-json",
+                    "application/*+json",
+                    "application/*+xml",
+                    "application/text",
+                    "application/vnd.microsoft.icon",
+                    "application/vnd-ms-fontobject",
+                    "application/x-font-ttf",
+                    "application/x-font-opentype",
+                    "application/x-font-truetype",
+                    "application/xmlfont/eot",
+                    "application/xml",
+                    "font/opentype",
+                    "font/otf",
+                    "font/eot",
+                    "image/svg+xml",
+                    "image/vnd.microsoft.icon"
+                  ]
+                }
+              }
+            ],
+            "criteriaMustSatisfy": "all",
+            "comments": "Compresses content to improve performance of clients with slow connections. Applies Last Mile Acceleration to requests when the returned object supports gzip compression."
+          }
+        ],
+        "behaviors": [
+          {
+            "name": "enhancedAkamaiProtocol",
+            "options": {
+              "display": ""
+            }
+          },
+          {
+            "name": "http2",
+            "options": {
+              "enabled": ""
+            }
+          },
+          {
+            "name": "allowTransferEncoding",
+            "options": {
+              "enabled": true
+            }
+          },
+          {
+            "name": "removeVary",
+            "options": {
+              "enabled": true
+            }
+          },
+          {
+            "name": "sureRoute",
+            "options": {
+              "enabled": false
+            }
+          },
+          {
+            "name": "prefetch",
+            "options": {
+              "enabled": true
+            }
+          }
+        ],
+        "criteria": [],
+        "criteriaMustSatisfy": "all",
+        "comments": "Improves the performance of delivering objects to end users. Behaviors in this rule are applied to all requests as appropriate."
+      },
+      {
+        "name": "Offload",
+        "children": [
+          {
+            "name": "CSS and JavaScript",
+            "children": [],
+            "behaviors": [
+              {
+                "name": "caching",
+                "options": {
+                  "behavior": "MAX_AGE",
+                  "mustRevalidate": false,
+                  "ttl": "1d"
+                }
+              },
+              {
+                "name": "prefreshCache",
+                "options": {
+                  "enabled": true,
+                  "prefreshval": 90
+                }
+              },
+              {
+                "name": "prefetchable",
+                "options": {
+                  "enabled": true
+                }
+              }
+            ],
+            "criteria": [
+              {
+                "name": "fileExtension",
+                "options": {
+                  "matchCaseSensitive": false,
+                  "matchOperator": "IS_ONE_OF",
+                  "values": [
+                    "css",
+                    "js"
+                  ]
+                }
+              }
+            ],
+            "criteriaMustSatisfy": "any",
+            "comments": "Overrides the default caching behavior for CSS and JavaScript objects that are cached on the edge server. Because these object types are dynamic, the TTL is brief."
+          },
+          {
+            "name": "Static Objects",
+            "children": [],
+            "behaviors": [
+              {
+                "name": "caching",
+                "options": {
+                  "behavior": "MAX_AGE",
+                  "mustRevalidate": false,
+                  "ttl": "7d"
+                }
+              },
+              {
+                "name": "prefreshCache",
+                "options": {
+                  "enabled": true,
+                  "prefreshval": 90
+                }
+              },
+              {
+                "name": "prefetchable",
+                "options": {
+                  "enabled": true
+                }
+              }
+            ],
+            "criteria": [
+              {
+                "name": "fileExtension",
+                "options": {
+                  "matchCaseSensitive": false,
+                  "matchOperator": "IS_ONE_OF",
+                  "values": [
+                    "aif",
+                    "aiff",
+                    "au",
+                    "avi",
+                    "bin",
+                    "bmp",
+                    "cab",
+                    "carb",
+                    "cct",
+                    "cdf",
+                    "class",
+                    "doc",
+                    "dcr",
+                    "dtd",
+                    "exe",
+                    "flv",
+                    "gcf",
+                    "gff",
+                    "gif",
+                    "grv",
+                    "hdml",
+                    "hqx",
+                    "ico",
+                    "ini",
+                    "jpeg",
+                    "jpg",
+                    "mov",
+                    "mp3",
+                    "nc",
+                    "pct",
+                    "pdf",
+                    "png",
+                    "ppc",
+                    "pws",
+                    "swa",
+                    "swf",
+                    "txt",
+                    "vbs",
+                    "w32",
+                    "wav",
+                    "wbmp",
+                    "wml",
+                    "wmlc",
+                    "wmls",
+                    "wmlsc",
+                    "xsd",
+                    "zip",
+                    "pict",
+                    "tif",
+                    "tiff",
+                    "mid",
+                    "midi",
+                    "ttf",
+                    "eot",
+                    "woff",
+                    "woff2",
+                    "otf",
+                    "svg",
+                    "svgz",
+                    "webp",
+                    "jxr",
+                    "jar",
+                    "jp2"
+                  ]
+                }
+              }
+            ],
+            "criteriaMustSatisfy": "any",
+            "comments": "Overrides the default caching behavior for images, music, and similar objects that are cached on the edge server. Because these object types are static, the TTL is long."
+          },
+          {
+            "name": "Uncacheable Responses",
+            "children": [],
+            "behaviors": [
+              {
+                "name": "downstreamCache",
+                "options": {
+                  "behavior": "TUNNEL_ORIGIN"
+                }
+              }
+            ],
+            "criteria": [
+              {
+                "name": "cacheability",
+                "options": {
+                  "matchOperator": "IS_NOT",
+                  "value": "CACHEABLE"
+                }
+              }
+            ],
+            "criteriaMustSatisfy": "all",
+            "comments": "Overrides the default downstream caching behavior for uncacheable object types. Instructs the edge server to pass Cache-Control and/or Expire headers from the origin to the client."
+          }
+        ],
+        "behaviors": [
+          {
+            "name": "caching",
+            "options": {
+              "behavior": "NO_STORE"
+            }
+          },
+          {
+            "name": "cacheError",
+            "options": {
+              "enabled": true,
+              "preserveStale": true,
+              "ttl": "10s"
+            }
+          },
+          {
+            "name": "downstreamCache",
+            "options": {
+              "allowBehavior": "LESSER",
+              "behavior": "ALLOW",
+              "sendHeaders": "CACHE_CONTROL_AND_EXPIRES",
+              "sendPrivate": false
+            }
+          },
+          {
+            "name": "tieredDistribution",
+            "options": {
+              "enabled": true,
+              "tieredDistributionMap": "CH2"
+            }
+          }
+        ],
+        "criteria": [],
+        "criteriaMustSatisfy": "all",
+        "comments": "Controls caching, which offloads traffic away from the origin. Most objects types are not cached. However, the child rules override this behavior for certain subsets of requests."
+      }
+    ],
+    "behaviors": [
+      {
+        "name": "origin",
+        "options": {
+          "cacheKeyHostname": "REQUEST_HOST_HEADER",
+          "compress": true,
+          "enableTrueClientIp": false,
+          "forwardHostHeader": "ORIGIN_HOSTNAME",
+          "httpPort": 80,
+          "httpsPort": 443,
+          "originSni": true,
+          "originType": "CUSTOMER",
+          "verificationMode": "PLATFORM_SETTINGS",
+          "hostname": "{{user.PMUSER_ORIGIN}}",
+          "originCertificate": "",
+          "ports": ""
+        }
+      },
+      {
+        "name": "allowPost",
+        "options": {
+          "allowWithoutContentLength": false,
+          "enabled": true
+        }
+      }
+    ],
+    "options": {
+      "is_secure": false
+    },
+    "variables": [
+    ],
+    "comments": "The behaviors in the Default Rule apply to all requests for the property hostname(s) unless another rule overrides the Default Rule settings."
+  }
+}


### PR DESCRIPTION
Now uses much simpler:

```hcl
hostnames = {
	"public.hostname" = "edge.hostname"
}
```