### PR TITLE
Don't deactivate unintentionally

### DIFF
--- a/akamai/resource_akamai_property_activation.go
+++ b/akamai/resource_akamai_property_activation.go
@@ -25,12 +25,10 @@ var akamaiPropertyActivationSchema = map[string]*schema.Schema{
 	"property": &schema.Schema{
 		Type:     schema.TypeString,
 		Required: true,
-		ForceNew: true,
 	},
 	"version": &schema.Schema{
 		Type:     schema.TypeInt,
 		Optional: true,
-		ForceNew: true,
 	},
 	"network": &schema.Schema{
 		Type:     schema.TypeString,


### PR DESCRIPTION
Because `property` and `version` were ForceNew, changing either of these would deactivate
the previous versions/property, possibly unintentionally. Not only would it block activating
the new version till the old one deactivated (causing temporary downtime), if the new version
couldn't be activated it would leave the property completely down.