### PR TITLE
IPv4 typo, don't try to deactivate a non-active version

### DIFF
--- a/akamai/resource_akamai_edge_hostname.go
+++ b/akamai/resource_akamai_edge_hostname.go
@@ -118,8 +118,8 @@ func resourceSecureEdgeHostNameCreate(d *schema.ResourceData, meta interface{}) 
 		ehn.DomainSuffix = "edgekey.net"
 		ehn.SecureNetwork = "ENHANCED_TLS"
 	case strings.HasSuffix(edgeHostname, ".akamaized.net"):
-		ehn.DomainPrefix = strings.TrimSuffix(edgeHostname, ".akamized.net")
-		ehn.DomainSuffix = "akamized.net"
+		ehn.DomainPrefix = strings.TrimSuffix(edgeHostname, ".akamaized.net")
+		ehn.DomainSuffix = "akamaized.net"
 		ehn.SecureNetwork = "SHARED_CERT"
 	}
 

--- a/akamai/resource_akamai_edge_hostname.go
+++ b/akamai/resource_akamai_edge_hostname.go
@@ -158,15 +158,16 @@ func resourceSecureEdgeHostNameCreate(d *schema.ResourceData, meta interface{}) 
 		}
 
 		log.Println("[DEBUG] Existing edge hostname FOUND = ", ehnFound.EdgeHostnameID)
+		d.SetId(ehnFound.EdgeHostnameID)
 	} else {
 		log.Printf("[DEBUG] Creating new edge hostname: %#v\n\n", ehn)
 		err = ehn.Save("")
 		if err != nil {
 			return err
 		}
+		d.SetId(ehn.EdgeHostnameID)
 	}
 
-	d.SetId(ehn.EdgeHostnameID)
 	d.Partial(false)
 
 	log.Println("[DEBUG] Done")

--- a/akamai/resource_akamai_edge_hostname.go
+++ b/akamai/resource_akamai_edge_hostname.go
@@ -125,7 +125,7 @@ func resourceSecureEdgeHostNameCreate(d *schema.ResourceData, meta interface{}) 
 
 	ipv4 := d.Get("ipv4").(bool)
 	if ipv4 {
-		ehn.IPVersionBehavior = "IPv4"
+		ehn.IPVersionBehavior = "IPV4"
 	}
 
 	ipv6 := d.Get("ipv6").(bool)

--- a/akamai/resource_akamai_edge_hostname.go
+++ b/akamai/resource_akamai_edge_hostname.go
@@ -3,6 +3,7 @@ package akamai
 import (
 	"errors"
 	"fmt"
+        "github.com/akamai/AkamaiOPEN-edgegrid-golang/jsonhooks-v1"
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/papi-v1"
 	"github.com/hashicorp/terraform/helper/schema"
 	"log"
@@ -146,12 +147,14 @@ func resourceSecureEdgeHostNameCreate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if ehnFound, err := edgeHostnames.FindEdgeHostname(ehn); ehnFound != nil && ehnFound.EdgeHostnameID != "" {
-		if ehnFound.IPVersionBehavior != ehn.IPVersionBehavior {
-			return fmt.Errorf("existing edge hostname found with different IP version (%s vs %s)", ehnFound.IPVersionBehavior, ehn.IPVersionBehavior)
+
+	        jsonBody, e := jsonhooks.Marshal(ehnFound)
+		if (e == nil) {
+			log.Printf("[DEBUG] EHN Found = %s\n", jsonBody);
 		}
 
-		if ehnFound.SecureNetwork != ehn.SecureNetwork {
-			return fmt.Errorf("existing edge hostname found on different network (%s vs %s)", ehnFound.SecureNetwork, ehn.SecureNetwork)
+		if ehnFound.IPVersionBehavior != ehn.IPVersionBehavior {
+			return fmt.Errorf("existing edge hostname found with different IP version (%s vs %s)", ehnFound.IPVersionBehavior, ehn.IPVersionBehavior)
 		}
 
 		log.Println("[DEBUG] Existing edge hostname FOUND = ", ehnFound.EdgeHostnameID)

--- a/akamai/resource_akamai_edge_hostname.go
+++ b/akamai/resource_akamai_edge_hostname.go
@@ -117,7 +117,7 @@ func resourceSecureEdgeHostNameCreate(d *schema.ResourceData, meta interface{}) 
 		ehn.DomainPrefix = strings.TrimSuffix(edgeHostname, ".edgekey.net")
 		ehn.DomainSuffix = "edgekey.net"
 		ehn.SecureNetwork = "ENHANCED_TLS"
-	case strings.HasSuffix(edgeHostname, ".akamized.net"):
+	case strings.HasSuffix(edgeHostname, ".akamaized.net"):
 		ehn.DomainPrefix = strings.TrimSuffix(edgeHostname, ".akamized.net")
 		ehn.DomainSuffix = "akamized.net"
 		ehn.SecureNetwork = "SHARED_CERT"


### PR DESCRIPTION
Typo - IPv4 > IPV4

resource_akamai_property_activation.go resourcePropertyActivationDelete was trying to determine if a version was currently active by using listActivations. However that won't achieve the desired result because that's a historical record & not a reflection of current state. Changed to get the current active version on the given network & then compare the version to the version we're trying to deactivate. If it's not the same then obviously the version we're trying to deactivate isn't active so do nothing.