### PR TITLE
Feature/datasource akamai activation

### DIFF
--- a/akamai/data_akamai_property_activation.go
+++ b/akamai/data_akamai_property_activation.go
@@ -1,0 +1,89 @@
+package akamai
+
+import (
+	"fmt"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/papi-v1"
+	"github.com/hashicorp/terraform/helper/schema"
+	"strings"
+)
+
+func dataSourcePropertyActivation() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcePropertyActivationRead,
+
+		Schema: map[string]*schema.Schema{
+			"property": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"version": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"staging_version": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"production_version": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+func dataSourcePropertyActivationRead(d *schema.ResourceData, meta interface{}) error {
+
+	property := papi.NewProperty(papi.NewProperties())
+	if strings.HasPrefix("prp_", d.Get("property").(string)) {
+		property.PropertyID = d.Get("property").(string)
+	} else {
+		propertySearch := findPropertyID(d)
+		property.PropertyID = propertySearch.PropertyID
+		err := property.GetProperty()
+		if err != nil {
+			return fmt.Errorf("unable to find id from propertyname")
+		}
+	}
+	err := property.GetProperty()
+	if err != nil {
+		return fmt.Errorf("unable to find property")
+	}
+
+	d.SetId(property.PropertyID + "-")
+
+	if version := property.LatestVersion; version != 0 {
+		d.Set("version", version)
+	}
+
+	if stagingVersion := property.StagingVersion; stagingVersion != 0 {
+		d.Set("staging_version", stagingVersion)
+	}
+
+	if productionVersion := property.ProductionVersion; productionVersion != 0 {
+		d.Set("production_version", productionVersion)
+	}
+
+	return nil
+}
+
+func findPropertyID(d *schema.ResourceData) *papi.Property {
+
+	propertySearch, err := papi.Search(papi.SearchByPropertyName, d.Get("property").(string))
+	if err != nil {
+		return nil
+	}
+
+	if err != nil || propertySearch == nil {
+		return nil
+	}
+	property := &papi.Property{
+		PropertyID: propertySearch.Versions.Items[0].PropertyID,
+	}
+
+	err = property.GetProperty()
+	if err != nil {
+		return nil
+	}
+
+	return property
+}

--- a/akamai/data_akamai_property_activation_test.go
+++ b/akamai/data_akamai_property_activation_test.go
@@ -1,0 +1,42 @@
+package akamai
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourcePropertyActivationComplete(t *testing.T) {
+	dataSourceName := "akamai_property_activation.test"
+	propertyName := "example-test"
+	group := "group"
+
+	config := testAccDataSourcePropertyActivationComplete(propertyName, group)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAkamaiPropertyActivationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "property"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
+					resource.TestCheckResourceAttr(dataSourceName, "version", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourcePropertyActivationComplete(propertyName string, group string) string {
+	t := testAccPropertyActivationComplete(propertyName, group)
+	return fmt.Sprintf(`
+%s
+
+data "akamai_property_activation" "test" {
+    property = "${akamai_property.property.name}"
+}
+`, t)
+}

--- a/akamai/resource_akamai_property_activation_test.go
+++ b/akamai/resource_akamai_property_activation_test.go
@@ -399,3 +399,144 @@ func testAccCheckAkamaiPropertyActivationLatest(s *terraform.State) error {
 	}
 	return nil
 }
+
+func testAccPropertyActivationComplete(nString string, gString string) string {
+	return fmt.Sprintf(`
+provider "akamai" {
+	
+}
+
+resource "akamai_property" "property" {
+	name = "%s"
+
+	contact = ["user@exampleterraform.io"]
+
+	product = "prd_Site_Accel"
+	cp_code = "${akamai_cp_code.cp_code.id}"
+	contract = "${data.akamai_contract.contract.id}"
+	group = "${data.akamai_group.group.id}"
+
+	hostnames = {
+		"terraform.example.org" = "${akamai_edge_hostname.test.edge_hostname}"
+	}
+
+	rule_format = "v2018-02-27"
+
+	rules = "${data.akamai_property_rules.rules.json}"
+}
+
+data "akamai_contract" "contract" {
+	group = "%s"
+}
+
+data "akamai_group" "group" {
+	name = "%s"
+}
+
+resource "akamai_cp_code" "cp_code" {
+	name = "terraform-testing"
+	contract = "${data.akamai_contract.contract.id}"
+	group = "${data.akamai_group.group.id}"
+	product = "prd_Site_Accel"
+}
+
+resource "akamai_edge_hostname" "test" {
+	product = "prd_Site_Accel"
+	contract = "${data.akamai_contract.contract.id}"
+	group = "${data.akamai_group.group.id}"
+	edge_hostname =  "terraform.example.org.edgesuite.net"
+	ipv4 = true
+	ipv6 = true
+}
+
+data "akamai_property_rules" "rules" {
+	rules {
+		behavior {
+			name =  "origin"
+			option { 
+					key =  "cacheKeyHostname"
+				value = "ORIGIN_HOSTNAME"
+			}
+			option { 
+				key =  "compress"
+				value = "true"
+			}
+			option { 
+				key =  "enableTrueClientIp"
+				value = "false"
+			}
+			option { 
+				key =  "forwardHostHeader"
+				value = "REQUEST_HOST_HEADER"
+			}
+			option { 
+				key =  "hostname"
+				value = "exampleterraform.io"
+			}
+			option { 
+				key =  "httpPort"
+				value = "80"
+			}
+			option { 
+				key =  "httpsPort"
+				value = "443"
+			}
+			option { 
+				key =  "originSni"
+				value = "true"
+			}
+			option { 
+				key =  "originType"
+				value = "CUSTOMER"
+			}
+			option { 
+				key =  "verificationMode"
+				value = "PLATFORM_SETTINGS"
+			}
+			option { 
+				key =  "originCertificate"
+				value = ""
+			}
+			option { 
+				key =  "ports"
+				value = ""
+			}
+		}
+		behavior {
+			name =  "cpCode"
+			option {
+				key =  "id"
+				value = "${akamai_cp_code.cp_code.id}"
+			}
+			option {
+				key =  "name"
+				value = "${akamai_cp_code.cp_code.name}"
+			}
+		}
+		behavior {
+			name =  "caching"
+			option {
+				key =  "behavior"
+				value = "MAX_AGE"
+			}
+			option {
+				key =  "mustRevalidate"
+				value = "false"
+			}
+			option {
+				key =  "ttl"
+				value = "1d"
+			}
+		}
+	}
+}
+
+resource "akamai_property_activation" "test" {
+	property = "${data.akamai_property_activation.test.id}"
+	contact = ["example@akamai.com"]
+	network = "STAGING"
+	activate = true 
+	version = "1"
+	}
+`, nString, gString, gString)
+}

--- a/go.mod
+++ b/go.mod
@@ -20,4 +20,3 @@ replace (
 
 replace github.com/h2non/gock => gopkg.in/h2non/gock.v1 v1.0.14
 
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -20,3 +20,4 @@ replace (
 
 replace github.com/h2non/gock => gopkg.in/h2non/gock.v1 v1.0.14
 
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/agl/ed25519 v0.0.0-20150830182803-278e1ec8e8a6/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/akamai/AkamaiOPEN-edgegrid-golang v0.8.0 h1:deI0mtQseP6qmCRJ+/Gk2RkklniIY3Rp2RTB38rPd1M=
 github.com/akamai/AkamaiOPEN-edgegrid-golang v0.8.0/go.mod h1:zpDJeKyp9ScW4NNrbdr+Eyxvry3ilGPewKoXw3XGN1k=
+github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.5 h1:6/ofsc2djpS+bsyOG10cDJI1ftigCiulAfIZpxSua6k=
+github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.5/go.mod h1:L3YOfsK9Dzvjxj1/Q5OG58SDCGGOwtzgi734Kpdc03c=
 github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190329064014-6e358769c32a h1:APorzFpCcv6wtD5vmRWYqNm4N55kbepL7c7kTq9XI6A=
 github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190329064014-6e358769c32a/go.mod h1:T9M45xf79ahXVelWoOBmH0y4aC1t5kXO5BxwyakgIGA=
 github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20190103054945-8205d1f41e70 h1:FrF4uxA24DF3ARNXVbUin3wa5fDLaB1Cy8mKks/LRz4=

--- a/go.sum
+++ b/go.sum
@@ -506,6 +506,7 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/h2non/gock.v1 v1.0.14/go.mod h1:sX4zAkdYX1TRGJ2JY156cFspQn4yRWn6p9EMdODlynE=
 gopkg.in/h2non/gock.v1 v1.0.15 h1:SzLqcIlb/fDfg7UvukMpNcWsu7sI5tWwL+KCATZqks0=
 gopkg.in/h2non/gock.v1 v1.0.15/go.mod h1:sX4zAkdYX1TRGJ2JY156cFspQn4yRWn6p9EMdODlynE=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,6 @@ github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/agl/ed25519 v0.0.0-20150830182803-278e1ec8e8a6/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/akamai/AkamaiOPEN-edgegrid-golang v0.8.0 h1:deI0mtQseP6qmCRJ+/Gk2RkklniIY3Rp2RTB38rPd1M=
 github.com/akamai/AkamaiOPEN-edgegrid-golang v0.8.0/go.mod h1:zpDJeKyp9ScW4NNrbdr+Eyxvry3ilGPewKoXw3XGN1k=
-github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.5 h1:6/ofsc2djpS+bsyOG10cDJI1ftigCiulAfIZpxSua6k=
-github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.5/go.mod h1:L3YOfsK9Dzvjxj1/Q5OG58SDCGGOwtzgi734Kpdc03c=
 github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190329064014-6e358769c32a h1:APorzFpCcv6wtD5vmRWYqNm4N55kbepL7c7kTq9XI6A=
 github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190329064014-6e358769c32a/go.mod h1:T9M45xf79ahXVelWoOBmH0y4aC1t5kXO5BxwyakgIGA=
 github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20190103054945-8205d1f41e70 h1:FrF4uxA24DF3ARNXVbUin3wa5fDLaB1Cy8mKks/LRz4=


### PR DESCRIPTION
Adding a data source gives the ability to activate the property based on the **prp_* ID** or the **property name**. It means the "**akamai_property_activation**" resources doesn't need to exist in the main tf file. If using a module that is quite generic where multiple products may consume it, it becomes difficult when the activation sits within the module. 

With the current provider there is no way to activate the property outside a module without first knowing the prp ID.



