### PR TITLE
Property datasource

### DIFF
--- a/akamai/data_akamai_property.go
+++ b/akamai/data_akamai_property.go
@@ -1,16 +1,16 @@
 package akamai
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
-	"log"
-        "bytes"
-        "encoding/json"
 	"github.com/hashicorp/terraform/helper/schema"
+	"log"
 )
 
 func dataSourceAkamaiProperty() *schema.Resource {
 	return &schema.Resource{
-		Read:   dataAkamaiPropertyRead,
+		Read: dataAkamaiPropertyRead,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -20,11 +20,10 @@ func dataSourceAkamaiProperty() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
-                        "rules": {
-                                Type:     schema.TypeString,
-                                Computed: true,
-                        },
-
+			"rules": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -33,26 +32,25 @@ func dataAkamaiPropertyRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading Property")
 
 	property := findProperty(d)
-	if (property == nil) {
+	if property == nil {
 		return fmt.Errorf("Can't find property")
 	}
 
-        _, ok := d.GetOk("version")
-        if ok {
+	_, ok := d.GetOk("version")
+	if ok {
 		property.LatestVersion = d.Get("version").(int)
 	}
 
-	rules, err := property.GetRules();
-	if (err != nil) {
+	rules, err := property.GetRules()
+	if err != nil {
 		return fmt.Errorf("Can't get rules for property")
 	}
 
 	jsonBody, err := json.Marshal(rules)
-        buf := bytes.NewBufferString("")
-        buf.Write(jsonBody)
+	buf := bytes.NewBufferString("")
+	buf.Write(jsonBody)
 
 	d.SetId(property.PropertyID)
 	d.Set("rules", buf.String())
 	return nil
 }
-

--- a/akamai/data_akamai_property.go
+++ b/akamai/data_akamai_property.go
@@ -38,7 +38,6 @@ func dataAkamaiPropertyRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
         _, ok := d.GetOk("version")
-
         if ok {
 		property.LatestVersion = d.Get("version").(int)
 	}

--- a/akamai/data_akamai_property.go
+++ b/akamai/data_akamai_property.go
@@ -33,7 +33,7 @@ func dataAkamaiPropertyRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading Property")
 
 	property := findProperty(d)
-	if property == nil {
+	if (property == nil) {
 		return fmt.Errorf("Can't find property")
 	}
 

--- a/akamai/data_akamai_property.go
+++ b/akamai/data_akamai_property.go
@@ -1,0 +1,81 @@
+package akamai
+
+import (
+	"fmt"
+	"log"
+        "bytes"
+        "encoding/json"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/papi-v1"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAkamaiProperty() *schema.Resource {
+	return &schema.Resource{
+		Read:   dataAkamaiPropertyRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+                        "rules": {
+                                Type:     schema.TypeString,
+                                Computed: true,
+                        },
+
+		},
+	}
+}
+
+func dataAkamaiPropertyRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Reading Property")
+
+	propertyName := d.Get("name").(string)
+
+	property := searchProperty(propertyName)
+	if property == nil {
+		return fmt.Errorf("Can't find property %s", propertyName)
+	}
+
+	rules, err := property.GetRules();
+	if (err != nil) {
+		return fmt.Errorf("Can't get rules for property %s", propertyName)
+	}
+
+	jsonBody, err := json.Marshal(rules)
+        buf := bytes.NewBufferString("")
+        buf.Write(jsonBody)
+
+	d.SetId(property.PropertyID)
+	d.Set("rules", buf.String())
+	return nil
+}
+
+
+func searchProperty(name string) *papi.Property {
+        results, err := papi.Search(papi.SearchByPropertyName, name)
+        if err != nil {
+                return nil
+        }
+
+        if err != nil || results == nil {
+                return nil
+        }
+
+        property := &papi.Property{
+                PropertyID: results.Versions.Items[0].PropertyID,
+                Group: &papi.Group{
+                        GroupID: results.Versions.Items[0].GroupID,
+                },
+                Contract: &papi.Contract{
+                        ContractID: results.Versions.Items[0].ContractID,
+                },
+        }
+
+        err = property.GetProperty()
+        if err != nil {
+                return nil
+        }
+
+        return property
+}
+

--- a/akamai/data_akamai_property.go
+++ b/akamai/data_akamai_property.go
@@ -16,6 +16,10 @@ func dataSourceAkamaiProperty() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"version": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
                         "rules": {
                                 Type:     schema.TypeString,
                                 Computed: true,
@@ -31,6 +35,12 @@ func dataAkamaiPropertyRead(d *schema.ResourceData, meta interface{}) error {
 	property := findProperty(d)
 	if property == nil {
 		return fmt.Errorf("Can't find property")
+	}
+
+        _, ok := d.GetOk("version")
+
+        if ok {
+		property.LatestVersion = d.Get("version").(int)
 	}
 
 	rules, err := property.GetRules();

--- a/akamai/data_akamai_property_test.go
+++ b/akamai/data_akamai_property_test.go
@@ -1,0 +1,48 @@
+package akamai
+
+import (
+	"log"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceProperty_basic(t *testing.T) {
+	dataSourceName := "data.akamai_property.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDataSourcePropertyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceProperty_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", "test"),
+					resource.TestCheckResourceAttr(dataSourceName, "version", "1"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceProperty_basic() string {
+	return `
+provider "akamai" {
+}
+
+data "akamai_property" "test" {
+	name = "test"
+	version = 1
+}
+`
+}
+
+func testAccCheckDataSourcePropertyDestroy(s *terraform.State) error {
+	log.Printf("[DEBUG] [Group] Searching for Property Delete skipped ")
+
+	return nil
+}

--- a/akamai/provider.go
+++ b/akamai/provider.go
@@ -139,6 +139,7 @@ func Provider() terraform.ResourceProvider {
 			"akamai_dns_record_set":  dataSourceDNSRecordSet(),
 			"akamai_group":           dataSourcePropertyGroups(),
 			"akamai_property_rules":  dataPropertyRules(),
+			"akamai_property":        dataSourceAkamaiProperty(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"akamai_cp_code":             resourceCPCode(),


### PR DESCRIPTION
Define a data source for Property Manager to allow you to access rule sets from another config. This is useful for a Golden Master scenario like so:-

data "akamai_property" "example" {
    name = "goldenmaster.wheep.co.uk"
    version = 2
}

...
  rules       = data.akamai_property.example.rules
...