### PR TITLE
CP Code Import

### DIFF
--- a/akamai/resource_akamai_cp_code.go
+++ b/akamai/resource_akamai_cp_code.go
@@ -113,6 +113,7 @@ func resourceCPCodePAPINewCPCodes(d *schema.ResourceData, meta interface{}) *pap
 	return papi.NewCpCodes(contract, group)
 }
 
+// resourceCPCodeImport expects that the ID passed in will be CP Code ID, Contract ID and Group ID as a single tring delimited by colons: cpc_12345:ctr_12345:grp_12345
 func resourceCPCodeImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	args, err := splitAndValidateCPCodeImportID(d.Id())
 	if err != nil {

--- a/website/docs/r/cp_code.html.markdown
+++ b/website/docs/r/cp_code.html.markdown
@@ -34,3 +34,12 @@ The following arguments are supported:
 * `contract` — (Required) The Contract ID
 * `group` — (Required) The Group ID
 * `product` — (Required) The Product ID
+
+## Import Command
+
+Import into Terraform state using CP Code ID, Contract ID and Group ID:
+
+```
+terraform import akamai_cp_code.foo cpc_123456:ctr_123456:grp_123456
+```
+All three IDs are required and must be in order delimeted with colons.

--- a/website/docs/r/cp_code.html.markdown
+++ b/website/docs/r/cp_code.html.markdown
@@ -42,4 +42,4 @@ Import into Terraform state using CP Code ID, Contract ID and Group ID:
 ```
 terraform import akamai_cp_code.foo cpc_123456:ctr_123456:grp_123456
 ```
-All three IDs are required and must be in order delimeted with colons.
+All three IDs are required and must be in order delimited with colons.


### PR DESCRIPTION
Adds Import function to CP Code resource.

Usage:

```
terraform import akamai_cp_code.foo cpc_123456:ctr_123456:grp_123456
```

All three IDs are required and must be in order delimeted with colons.

Also updates documentation to reflect new functionality.