### PR TITLE
Support TSIG Keys, Alias Zone, Record Import, SOA, AKAMAITLC, AKAMAICDN Records. Fixes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ branches:
 
 language: go
 go:
-- "1.11.x"
+- "1.13.x"
 
 env:
   - GO111MODULE=on

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ branches:
 
 language: go
 go:
-- "1.13.x"
+- "1.11.x"
 
 env:
   - GO111MODULE=on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
 ## 0.6.0 (Unreleased)
+* [ADD] Support the creation of DNS records of type AKAMAICDN (`akamai_dns`) [GH-53]
+* [ADD] Support akamai_dns_record Import (`akamai_dns`) [GH-69]
+* [FIX] Cannot remove a backup_cname from GTM property (`akamai_gtm`) [GH-124]
+* [ADD] DNS Alias Zone Support (`akamai_dns`) [GH-125]
+* [ADD] DNS TSIG Key support (`akamai_dns`) [GH-126]
+* [ADD] DNS SOA, AKAMAITLC Record Support (`akamai_dns`) [GH-127]
+* [FIX] Inverted Parameters - DNS Record Type NAPTR (`akamai_dns`) [GH-130]
+* [FIX] Inverted Parameters - DNS Record Type NSEC3 (`akamai_dns`) [GH-131]
+* [FIX] Inverted Parameters - DNS Record Type NSEC3PARAM (`akamai_dns`) [GH-132]
+* [FIX] Inverted Parameters - DNS Record Type RRSIG (`akamai_dns`) [GH-133]
+* [FIX] Inverted Parameters - DNS Record Type DS (`akamai_dns`) [GH-134]
+
 ## 0.5.0 (March 06, 2020)
 * [FIX] Release edgehostnames and products caching edge library v0.9.10 (`akamai_property`)
 

--- a/akamai/provider.go
+++ b/akamai/provider.go
@@ -222,6 +222,7 @@ func getConfigDNSV2Service(d resourceData) (*edgegrid.Config, error) {
 	}
 
 	dnsv2.Init(DNSv2Config)
+	edgegrid.SetupLogging()
 	return &DNSv2Config, nil
 }
 
@@ -240,6 +241,7 @@ func getConfigGTMV1Service(d resourceData) (*edgegrid.Config, error) {
 		}
 
 		gtm.Init(GTMv1Config)
+		edgegrid.SetupLogging()
 		return &GTMv1Config, nil
 	}
 

--- a/akamai/resource_akamai_dns_record_test.go
+++ b/akamai/resource_akamai_dns_record_test.go
@@ -27,7 +27,6 @@ data "akamai_group" "group" {
 resource "akamai_dns_zone" "test_zone" {
 	contract = "${data.akamai_contract.contract.id}"
 	zone = "exampleterraform.io"
-	masters = ["1.2.3.4" , "1.2.3.5"]
 	type = "primary"
 	comment =  "This is a test zone"
 	group     = "${data.akamai_group.group.id}"
@@ -59,7 +58,6 @@ data "akamai_group" "group" {
 resource "akamai_dns_zone" "test_zone" {
 	contract = "${data.akamai_contract.contract.id}"
 	zone = "exampleterraform.io"
-	masters = ["1.2.3.4" , "1.2.3.5"]
 	type = "primary"
 	comment =  "This is a test zone"
 	group     = "${data.akamai_group.group.id}"

--- a/akamai/resource_akamai_dns_zone.go
+++ b/akamai/resource_akamai_dns_zone.go
@@ -161,7 +161,7 @@ func resourceDNSv2ZoneCreate(d *schema.ResourceData, meta interface{}) error {
 			if e != nil {
 				return e
 			}
-			d.SetId(fmt.Sprintf("%s-%s-%s", zone.VersionId, zone.Zone, hostname))
+			d.SetId(fmt.Sprintf("%s:%s:%s", zone.VersionId, zone.Zone, hostname))
 			return resourceDNSv2ZoneRead(d, meta)
 		} else {
 			return e
@@ -171,7 +171,11 @@ func resourceDNSv2ZoneCreate(d *schema.ResourceData, meta interface{}) error {
 	// Save the zone to the API
 	log.Printf("[DEBUG] [Akamai DNSv2] Updating zone %v", zonecreate)
 	// Give terraform the ID
-	d.SetId(fmt.Sprintf("%s-%s-%s", zone.VersionId, zone.Zone, hostname))
+	if d.Id() == "" || strings.Contains(d.Id(), ":") {
+		d.SetId(fmt.Sprintf("%s:%s:%s", zone.VersionId, zone.Zone, hostname))
+	} else {
+		d.SetId(fmt.Sprintf("%s-%s-%s", zone.VersionId, zone.Zone, hostname))
+	}
 	return resourceDNSv2ZoneRead(d, meta)
 
 }
@@ -206,11 +210,15 @@ func resourceDNSv2ZoneRead(d *schema.ResourceData, meta interface{}) error {
 	populateDNSv2ZoneState(d, zone)
 
 	log.Printf("[DEBUG] [Akamai DNSv2] READ %v", zone)
-	d.SetId(fmt.Sprintf("%s-%s-%s", zone.VersionId, zone.Zone, hostname))
+	if strings.Contains(d.Id(), ":") {
+		d.SetId(fmt.Sprintf("%s:%s:%s", zone.VersionId, zone.Zone, hostname))
+	} else {
+		d.SetId(fmt.Sprintf("%s-%s-%s", zone.VersionId, zone.Zone, hostname))
+	}
 	return nil
 }
 
-// Create a new DNS Record
+// Update DNS Zone
 func resourceDNSv2ZoneUpdate(d *schema.ResourceData, meta interface{}) error {
 	// only allow one record to be created at a time
 	// this prevents lost data if you are using a counter/dynamic variables
@@ -257,7 +265,11 @@ func resourceDNSv2ZoneUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Give terraform the ID
-	d.SetId(fmt.Sprintf("%s-%s-%s", zone.VersionId, zone.Zone, hostname))
+	if strings.Contains(d.Id(), ":") {
+		d.SetId(fmt.Sprintf("%s:%s:%s", zone.VersionId, zone.Zone, hostname))
+	} else {
+		d.SetId(fmt.Sprintf("%s-%s-%s", zone.VersionId, zone.Zone, hostname))
+	}
 	return resourceDNSv2ZoneRead(d, meta)
 }
 
@@ -276,7 +288,7 @@ func resourceDNSv2ZoneImport(d *schema.ResourceData, meta interface{}) ([]*schem
 	populateDNSv2ZoneState(d, zone)
 
 	// Give terraform the ID
-	d.SetId(fmt.Sprintf("%s-%s-%s", zone.VersionId, zone.Zone, hostname))
+	d.SetId(fmt.Sprintf("%s:%s:%s", zone.VersionId, zone.Zone, hostname))
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/akamai/resource_akamai_dns_zone.go
+++ b/akamai/resource_akamai_dns_zone.go
@@ -58,7 +58,7 @@ func resourceDNSv2Zone() *schema.Resource {
 			},
 			"sign_and_serve": {
 				Type:     schema.TypeBool,
-				Required: true,
+				Optional: true,
 			},
 			"sign_and_serve_algorithm": {
 				Type:     schema.TypeString,
@@ -143,17 +143,17 @@ func resourceDNSv2ZoneCreate(d *schema.ResourceData, meta interface{}) error {
 			if e != nil {
 				return e
 			}
-
-			// Indirectly create NS and SOA records
-			e = zonecreate.SaveChangelist()
-			if e != nil {
-				return e
+			if zonetype == "PRIMARY" {
+				// Indirectly create NS and SOA records
+				e = zonecreate.SaveChangelist()
+				if e != nil {
+					return e
+				}
+				e = zonecreate.SubmitChangelist()
+				if e != nil {
+					return e
+				}
 			}
-			e = zonecreate.SubmitChangelist()
-			if e != nil {
-				return e
-			}
-
 			zone, e := dnsv2.GetZone(hostname)
 			if e != nil {
 				return e

--- a/akamai/resource_akamai_dns_zone.go
+++ b/akamai/resource_akamai_dns_zone.go
@@ -1,7 +1,7 @@
 package akamai
 
 import (
-	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -60,11 +60,55 @@ func resourceDNSv2Zone() *schema.Resource {
 				Type:     schema.TypeBool,
 				Required: true,
 			},
+			"sign_and_serve_algorithm": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"end_customer_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"target": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tsig_key": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"algorithm": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"secret": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"version_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"alias_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"activation_state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
 
-// Create a new DNS Record
 func resourceDNSv2ZoneCreate(d *schema.ResourceData, meta interface{}) error {
 	// only allow one record to be created at a time
 	// this prevents lost data if you are using a counter/dynamic variables
@@ -73,25 +117,14 @@ func resourceDNSv2ZoneCreate(d *schema.ResourceData, meta interface{}) error {
 	hostname := d.Get("zone").(string)
 	zonetype := d.Get("type").(string)
 	masterlist := d.Get("masters").(*schema.Set).List()
-	masters := make([]string, 0, len(masterlist))
-
 	if zonetype == "SECONDARY" && len(masterlist) == 0 {
 		return fmt.Errorf("DNS Secondary zone requires masters for zone %v", hostname)
 	}
-
-	if len(masterlist) > 0 {
-		for _, master := range masterlist {
-			masters = append(masters, master.(string))
-		}
-
-	}
-
-	comment := d.Get("comment").(string)
-	signandserve := d.Get("sign_and_serve").(bool)
 	contract := strings.TrimPrefix(d.Get("contract").(string), "ctr_")
 	group := strings.TrimPrefix(d.Get("group").(string), "grp_")
 	zonequerystring := dnsv2.ZoneQueryString{Contract: contract, Group: group}
-	zonecreate := dnsv2.ZoneCreate{Zone: hostname, Type: zonetype, Masters: masters, Comment: comment, SignAndServe: signandserve}
+	zonecreate := &dnsv2.ZoneCreate{Zone: hostname, Type: zonetype}
+	populateDNSv2ZoneObject(d, zonecreate)
 
 	// First try to get the zone from the API
 	log.Printf("[DEBUG] [Akamai DNSv2] Searching for zone [%s]", hostname)
@@ -111,11 +144,11 @@ func resourceDNSv2ZoneCreate(d *schema.ResourceData, meta interface{}) error {
 				return e
 			}
 
+			// Indirectly create NS and SOA records
 			e = zonecreate.SaveChangelist()
 			if e != nil {
 				return e
 			}
-
 			e = zonecreate.SubmitChangelist()
 			if e != nil {
 				return e
@@ -163,6 +196,11 @@ func resourceDNSv2ZoneRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
+	// Populate state with returned field values ... except zone and type
+	if zone.Type != d.Get("type").(string) {
+		return errors.New(fmt.Sprintf("Zone type has changed from %s to %s", d.Get("type").(string), zone.Type))
+	}
+	populateDNSv2ZoneState(d, zone)
 
 	log.Printf("[DEBUG] [Akamai DNSv2] READ %v", zone)
 	d.SetId(fmt.Sprintf("%s-%s-%s", zone.VersionId, zone.Zone, hostname))
@@ -177,47 +215,33 @@ func resourceDNSv2ZoneUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	hostname := d.Get("zone").(string)
 	contract := d.Get("contract").(string)
-	zonetype := d.Get("type").(string)
-	masterlist := d.Get("masters").(*schema.Set).List()
-	masters := make([]string, 0, len(masterlist))
-	if len(masterlist) > 0 {
-		for _, master := range masterlist {
-			masters = append(masters, master.(string))
-		}
-
-	}
-	comment := d.Get("comment").(string)
 	group := d.Get("group").(string)
-	signandserve := d.Get("sign_and_serve").(bool)
+	zonetype := d.Get("type").(string)
 	zonequerystring := dnsv2.ZoneQueryString{Contract: contract, Group: group}
-	zonecreate := dnsv2.ZoneCreate{Zone: hostname, Type: zonetype, Masters: masters, Comment: comment, SignAndServe: signandserve}
 
-	b, err := json.Marshal(zonecreate)
-	if err != nil {
-		fmt.Println(err)
-		return err
-	}
-	fmt.Println(string(b))
-	log.Printf("[DEBUG] [Akamai DNSv2] Searching for zone %s", string(b))
-	// First try to get the zone from the API
-	log.Printf("[DEBUG] [Akamai DNSv2] Searching for zone [%s]", hostname)
-	log.Printf("[DEBUG] [Akamai DNSv2] Searching for zone [%v]", zonecreate)
 	log.Printf("[INFO] [Akamai DNSv2] Searching for zone [%s]", hostname)
 	zone, e := dnsv2.GetZone(hostname)
-
 	if e != nil {
 		// If there's no existing zone we'll create a blank one
 		if dnsv2.IsConfigDNSError(e) && e.(dnsv2.ConfigDNSError).NotFound() == true {
-			// if the zone is not found/404 we will create a new
-			// blank zone for the records to be added to and continue
 			log.Printf("[DEBUG] [Akamai DNS] [ERROR] %s", e.Error())
-			log.Printf("[DEBUG] [Akamai DNS] Creating new zone")
-			//zonecreate := dnsv2.NewZone(zonecreate)
-			e = nil
+			// Something drastically wrong if we are trying to update a non existent zone!
+			return errors.New(fmt.Sprintf("Attempt to update non existent zone: %s", hostname))
 		} else {
 			return e
 		}
 	}
+	// Create Zone Post obj and copy Received vals over
+	zonecreate := &dnsv2.ZoneCreate{Zone: hostname, Type: zonetype}
+	zonecreate.Masters = zone.Masters
+	zonecreate.Comment = zone.Comment
+	zonecreate.SignAndServe = zone.SignAndServe
+	zonecreate.SignAndServeAlgorithm = zone.SignAndServeAlgorithm
+	zonecreate.Target = zone.Target
+	zonecreate.EndCustomerId = zone.EndCustomerId
+	zonecreate.ContractId = zone.ContractId
+	zonecreate.TsigKey = zone.TsigKey
+	populateDNSv2ZoneObject(d, zonecreate)
 
 	// Save the zone to the API
 	log.Printf("[DEBUG] [Akamai DNSv2] Saving zone %v", zonecreate)
@@ -233,14 +257,13 @@ func resourceDNSv2ZoneUpdate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceDNSv2ZoneImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	hostname := d.Id()
-	masterlist := d.Get("masters").(*schema.Set).List()
-	masters := make([]string, 0, len(masterlist))
-	if len(masterlist) > 0 {
-		for _, master := range masterlist {
-			masters = append(masters, master.(string))
+	/*
+		idParts := strings.Split(d.Id(), "-")
+		if len(idParts) != 3 {
+			errors.New(fmt.Sprintf("Invalid Id for Zone Import: %s", d.Id()))
 		}
-
-	}
+		hostname := idParts[2]
+	*/
 	// find the zone first
 	log.Printf("[INFO] [Akamai DNS] Searching for zone [%s]", hostname)
 	zone, err := dnsv2.GetZone(hostname)
@@ -248,9 +271,9 @@ func resourceDNSv2ZoneImport(d *schema.ResourceData, meta interface{}) ([]*schem
 		return nil, err
 	}
 
-	// assign each of the record sets to the resource data
-	//marshalResourceDatav2(d, zone)
-	d.Set("zone", zone)
+	d.Set("zone", zone.Zone)
+	d.Set("type", zone.Type)
+	populateDNSv2ZoneState(d, zone)
 
 	// Give terraform the ID
 	d.SetId(fmt.Sprintf("%s-%s-%s", zone.VersionId, zone.Zone, hostname))
@@ -296,4 +319,70 @@ func validateZoneType(v interface{}, k string) (ws []string, es []error) {
 		es = append(es, fmt.Errorf("Type must be PRIMARY, SECONDARY, or ALIAS"))
 	}
 	return
+}
+
+// populate zone state based on API response.
+func populateDNSv2ZoneState(d *schema.ResourceData, zoneresp *dnsv2.ZoneResponse) {
+
+	d.Set("masters", zoneresp.Masters)
+	d.Set("comment", zoneresp.Comment)
+	d.Set("sign_and_serve", zoneresp.SignAndServe)
+	d.Set("sign_and_serve_algorithm", zoneresp.SignAndServeAlgorithm)
+	d.Set("target", zoneresp.Target)
+	d.Set("end_customer_id", zoneresp.EndCustomerId)
+	tsigListNew := make([]interface{}, 0)
+	if zoneresp.TsigKey != nil {
+		tsigNew := map[string]interface{}{
+			"name":      zoneresp.TsigKey.Name,
+			"algorithm": zoneresp.TsigKey.Algorithm,
+			"secret":    zoneresp.TsigKey.Secret,
+		}
+		tsigListNew = append(tsigListNew, tsigNew)
+	}
+	d.Set("tsig_key", tsigListNew)
+	d.Set("activation_state", zoneresp.ActivationState)
+	d.Set("alias_count", zoneresp.AliasCount)
+	d.Set("version_id", zoneresp.VersionId)
+}
+
+// populate zone object based on current config.
+func populateDNSv2ZoneObject(d *schema.ResourceData, zone *dnsv2.ZoneCreate) {
+
+	if v, ok := d.GetOk("masters"); ok {
+		masterlist := v.(*schema.Set).List()
+		masters := make([]string, 0, len(masterlist))
+		if len(masterlist) > 0 {
+			for _, master := range masterlist {
+				masters = append(masters, master.(string))
+			}
+		}
+		zone.Masters = masters
+	}
+	if v, ok := d.GetOk("comment"); ok {
+		zone.Comment = v.(string)
+	}
+	zone.SignAndServe = d.Get("sign_and_serve").(bool)
+	if v, ok := d.GetOk("sign_and_serve_algorithm"); ok {
+		zone.SignAndServeAlgorithm = v.(string)
+	}
+	if v, ok := d.GetOk("target"); ok {
+		zone.Target = v.(string)
+	}
+	if v, ok := d.GetOk("end_customer_id"); ok {
+		zone.EndCustomerId = v.(string)
+	}
+	v := d.Get("tsig_key")
+	log.Printf("[DEBUG] [Akamai DNSV2] tsig get [%v]", v)
+	if v != nil && len(v.([]interface{})) > 0 {
+		tsigKeyList := v.([]interface{})
+		tsigKeyMap := tsigKeyList[0].(map[string]interface{})
+		zone.TsigKey = &dnsv2.TSIGKey{
+			Name:      tsigKeyMap["name"].(string),
+			Algorithm: tsigKeyMap["algorithm"].(string),
+			Secret:    tsigKeyMap["secret"].(string),
+		}
+		log.Printf("[DEBUG] [Akamai DNSV2] Generated TsigKey [%v]", zone.TsigKey)
+	} else {
+		zone.TsigKey = nil
+	}
 }

--- a/akamai/resource_akamai_dns_zone.go
+++ b/akamai/resource_akamai_dns_zone.go
@@ -261,15 +261,9 @@ func resourceDNSv2ZoneUpdate(d *schema.ResourceData, meta interface{}) error {
 	return resourceDNSv2ZoneRead(d, meta)
 }
 
+// Import Zone. Id is the zone
 func resourceDNSv2ZoneImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	hostname := d.Id()
-	/*
-		idParts := strings.Split(d.Id(), "-")
-		if len(idParts) != 3 {
-			errors.New(fmt.Sprintf("Invalid Id for Zone Import: %s", d.Id()))
-		}
-		hostname := idParts[2]
-	*/
 	// find the zone first
 	log.Printf("[INFO] [Akamai DNS] Searching for zone [%s]", hostname)
 	zone, err := dnsv2.GetZone(hostname)

--- a/akamai/resource_akamai_dns_zone.go
+++ b/akamai/resource_akamai_dns_zone.go
@@ -161,7 +161,7 @@ func resourceDNSv2ZoneCreate(d *schema.ResourceData, meta interface{}) error {
 			if e != nil {
 				return e
 			}
-			d.SetId(fmt.Sprintf("%s:%s:%s", zone.VersionId, zone.Zone, hostname))
+			d.SetId(fmt.Sprintf("%s#%s#%s", zone.VersionId, zone.Zone, hostname))
 			return resourceDNSv2ZoneRead(d, meta)
 		} else {
 			return e
@@ -171,8 +171,8 @@ func resourceDNSv2ZoneCreate(d *schema.ResourceData, meta interface{}) error {
 	// Save the zone to the API
 	log.Printf("[DEBUG] [Akamai DNSv2] Updating zone %v", zonecreate)
 	// Give terraform the ID
-	if d.Id() == "" || strings.Contains(d.Id(), ":") {
-		d.SetId(fmt.Sprintf("%s:%s:%s", zone.VersionId, zone.Zone, hostname))
+	if d.Id() == "" || strings.Contains(d.Id(), "#") {
+		d.SetId(fmt.Sprintf("%s#%s#%s", zone.VersionId, zone.Zone, hostname))
 	} else {
 		d.SetId(fmt.Sprintf("%s-%s-%s", zone.VersionId, zone.Zone, hostname))
 	}
@@ -210,8 +210,8 @@ func resourceDNSv2ZoneRead(d *schema.ResourceData, meta interface{}) error {
 	populateDNSv2ZoneState(d, zone)
 
 	log.Printf("[DEBUG] [Akamai DNSv2] READ %v", zone)
-	if strings.Contains(d.Id(), ":") {
-		d.SetId(fmt.Sprintf("%s:%s:%s", zone.VersionId, zone.Zone, hostname))
+	if strings.Contains(d.Id(), "#") {
+		d.SetId(fmt.Sprintf("%s#%s#%s", zone.VersionId, zone.Zone, hostname))
 	} else {
 		d.SetId(fmt.Sprintf("%s-%s-%s", zone.VersionId, zone.Zone, hostname))
 	}
@@ -265,8 +265,8 @@ func resourceDNSv2ZoneUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Give terraform the ID
-	if strings.Contains(d.Id(), ":") {
-		d.SetId(fmt.Sprintf("%s:%s:%s", zone.VersionId, zone.Zone, hostname))
+	if strings.Contains(d.Id(), "#") {
+		d.SetId(fmt.Sprintf("%s#%s#%s", zone.VersionId, zone.Zone, hostname))
 	} else {
 		d.SetId(fmt.Sprintf("%s-%s-%s", zone.VersionId, zone.Zone, hostname))
 	}

--- a/akamai/resource_akamai_dns_zone_test.go
+++ b/akamai/resource_akamai_dns_zone_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-var testAccAkamaiDNSZoneConfig = fmt.Sprintf(`
+var testAccAkamaiDNSPrimaryZoneConfig = fmt.Sprintf(`
 provider "akamai" {
   dns_section = "dns"
 }
@@ -26,18 +26,39 @@ data "akamai_contract" "contract" {
 data "akamai_group" "group" {
 }
 
-resource "akamai_dns_zone" "test_zone" {
+resource "akamai_dns_zone" "primary_test_zone" {
 	contract = "${data.akamai_contract.contract.id}"
-	zone = "exampleterraform.io"
-	masters = ["1.2.3.4" , "1.2.3.5"]
+	zone = "primaryexampleterraform.io"
 	type = "primary"
-	comment =  "This is a test zone"
+	comment =  "This is a test primary zone"
 	group     = "${data.akamai_group.group.id}"
 	sign_and_serve = false
 }
 `)
 
-var testAccAkamaiDNSZoneConfigWithCounter = fmt.Sprintf(`
+var testAccAkamaiDNSSecondaryZoneConfig = fmt.Sprintf(`
+provider "akamai" {
+  dns_section = "dns"
+}
+locals {
+  zone = "akavdev.net"
+}
+data "akamai_contract" "contract" {
+}
+data "akamai_group" "group" {
+}
+resource "akamai_dns_zone" "test_secondary_zone" {
+	contract = "${data.akamai_contract.contract.id}"
+	zone = "secondaryexampleterraform.io"
+	masters = ["1.2.3.4" , "1.2.3.5"]
+	type = "secondary"
+	comment =  "This is a secondary test zone"
+	group     = "${data.akamai_group.group.id}"
+	sign_and_serve = false
+}
+`)
+
+var testAccAkamaiDNSPrimaryZoneConfigWithCounter = fmt.Sprintf(`
 provider "akamai" {
   papi_section = "dns"
   dns_section = "dns"
@@ -49,25 +70,24 @@ data "akamai_contract" "contract" {
 data "akamai_group" "group" {
 }
 
-resource "akamai_dns_zone" "test_zone" {
+resource "akamai_dns_zone" "primary_test_zone" {
 	contract = "${data.akamai_contract.contract.id}"
-	zone = "exampleterraform.io"
-	masters = ["1.2.3.4" , "1.2.3.5"]
+	zone = "primaryexampleterraform.io"
 	type = "primary"
-	comment =  "This is a test zone"
+	comment =  "This is a test primary zone"
 	group     = "${data.akamai_group.group.id}"
 	sign_and_serve = false
 }
 `)
 
-func TestAccAkamaiDNSZone_basic(t *testing.T) {
+func TestAccAkamaiDNSPrimaryZone_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAkamaiDNSZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAkamaiDNSZoneConfig,
+				Config: testAccAkamaiDNSPrimaryZoneConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAkamaiDNSZoneExists,
 				),
@@ -76,14 +96,30 @@ func TestAccAkamaiDNSZone_basic(t *testing.T) {
 	})
 }
 
-func TestAccAkamaiDNSZone_counter(t *testing.T) {
+func TestAccAkamaiDNSSecondaryZone_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAkamaiDNSZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAkamaiDNSZoneConfigWithCounter,
+				Config: testAccAkamaiDNSSecondaryZoneConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAkamaiDNSZoneExists,
+				),
+			},
+		},
+	})
+}
+
+func TestAccAkamaiDNSPrimaryZone_counter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAkamaiDNSZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAkamaiDNSPrimaryZoneConfigWithCounter,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAkamaiDNSZoneExists,
 				),

--- a/akamai/resource_akamai_gtm_asmap.go
+++ b/akamai/resource_akamai_gtm_asmap.go
@@ -82,6 +82,7 @@ func parseResourceASmapId(id string) (string, string, error) {
 
 }
 
+// Util method to validate default datacenter and create if necc
 func validateDefaultDC(ddcField []interface{}, domain string) error {
 
 	if len(ddcField) == 0 {
@@ -96,7 +97,7 @@ func validateDefaultDC(ddcField []interface{}, domain string) error {
 		if err != nil {
 			_, ok := err.(gtm.CommonError)
 			if !ok {
-				return fmt.Errorf("[ERROR] AsMapCreate Unexpected error verifying Default Datacenter exists: %s", err.Error())
+				return fmt.Errorf("[ERROR] MapCreate Unexpected error verifying Default Datacenter exists: %s", err.Error())
 			}
 		}
 		// ddc doesn't exist
@@ -105,7 +106,7 @@ func validateDefaultDC(ddcField []interface{}, domain string) error {
 		}
 		ddc, err := gtm.CreateMapsDefaultDatacenter(domain) // create if not already.
 		if ddc == nil {
-			return fmt.Errorf("[ERROR] AsMapCreate failed on Default Datacenter check: %s", err.Error())
+			return fmt.Errorf("[ERROR] MapCreate failed on Default Datacenter check: %s", err.Error())
 		}
 	}
 
@@ -390,7 +391,7 @@ func populateTerraformAsAssignmentsState(d *schema.ResourceData, as *gtm.AsMap) 
 		}
 		a["datacenter_id"] = aObject.DatacenterId
 		a["nickname"] = aObject.Nickname
-		a["as_numbers"] = aObject.AsNumbers
+		a["as_numbers"] = reconcileTerraformLists(a["as_numbers"].([]interface{}), convertInt64ToInterfaceList(aObject.AsNumbers))
 		// remove object
 		delete(objectInventory, objIndex)
 	}

--- a/akamai/resource_akamai_gtm_asmap_test.go
+++ b/akamai/resource_akamai_gtm_asmap_test.go
@@ -1,0 +1,301 @@
+package akamai
+
+import (
+	"fmt"
+	gtm "github.com/akamai/AkamaiOPEN-edgegrid-golang/configgtm-v1_4"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"log"
+	"strconv"
+	"testing"
+)
+
+var testAccAkamaiGTMAsMapConfig = fmt.Sprintf(`
+provider "akamai" {
+  gtm_section = "gtm"
+}
+
+locals {
+  	domain = "%s"
+}
+
+data "akamai_contract" "contract" {
+}
+
+data "akamai_group" "group" {
+}
+
+data "akamai_gtm_default_datacenter" "default_datacenter" {
+    domain = akamai_gtm_domain.test_domain.name
+    datacenter = 5400
+}
+
+resource "akamai_gtm_domain" "test_domain" {
+        name = local.domain
+        type = "weighted"
+	contract = data.akamai_contract.contract.id
+	comment =  "This is a test zone"
+	group  = data.akamai_group.group.id
+        load_imbalance_percentage = 10
+	wait_on_complete = false
+}
+
+resource "akamai_gtm_datacenter" "test_as_datacenter" {
+    domain = akamai_gtm_domain.test_domain.name
+    nickname = "test_as_datacenter"
+    wait_on_complete = false
+    default_load_object {
+        load_object = "test"
+        load_object_port = 80
+        load_servers = ["1.2.3.4", "1.2.3.5"]
+    }
+    depends_on = [
+         akamai_gtm_domain.test_domain
+    ]
+}
+
+resource "akamai_gtm_asmap" "test_as" {
+    domain = akamai_gtm_domain.test_domain.name
+    name = "test_asmap"
+    default_datacenter {
+        datacenter_id = data.akamai_gtm_default_datacenter.default_datacenter.datacenter_id
+        nickname = data.akamai_gtm_default_datacenter.default_datacenter.nickname
+    }
+    assignment {
+        datacenter_id = akamai_gtm_datacenter.test_as_datacenter.datacenter_id
+        nickname = akamai_gtm_datacenter.test_as_datacenter.nickname
+        as_numbers = [17334]
+    }
+    wait_on_complete = false
+    depends_on = [
+        akamai_gtm_domain.test_domain,
+        akamai_gtm_datacenter.test_as_datacenter
+    ]
+}`, gtm_test_domain)
+
+var testAccAkamaiGTMAsMapUpdateConfig = fmt.Sprintf(`
+provider "akamai" {
+  gtm_section = "gtm"
+} 
+
+locals {
+        domain = "%s"
+}       
+
+data "akamai_contract" "contract" {
+}
+
+data "akamai_group" "group" {
+}
+
+data "akamai_gtm_default_datacenter" "default_datacenter" {
+    domain = akamai_gtm_domain.test_domain.name
+    datacenter = 5400
+}
+
+resource "akamai_gtm_domain" "test_domain" {
+        name = local.domain
+        type = "weighted"
+        contract = data.akamai_contract.contract.id
+        comment =  "This is a test zone"
+        group  = data.akamai_group.group.id
+        load_imbalance_percentage = 10
+        wait_on_complete = false
+}
+
+resource "akamai_gtm_datacenter" "test_as_datacenter" {
+    domain = akamai_gtm_domain.test_domain.name
+    nickname = "test_as_datacenter"
+    wait_on_complete = false
+    default_load_object {
+        load_object = "test"
+        load_object_port = 80
+        load_servers = ["1.2.3.4", "1.2.3.5"]
+    }  
+    depends_on = [
+         akamai_gtm_domain.test_domain
+    ]    
+}  
+
+resource "akamai_gtm_asmap" "test_as" {
+    domain = akamai_gtm_domain.test_domain.name
+    name = "test_asmap"
+    default_datacenter {
+        datacenter_id = data.akamai_gtm_default_datacenter.default_datacenter.datacenter_id
+        nickname = data.akamai_gtm_default_datacenter.default_datacenter.nickname
+    }
+    assignment {
+        datacenter_id = akamai_gtm_datacenter.test_as_datacenter.datacenter_id
+        nickname = akamai_gtm_datacenter.test_as_datacenter.nickname
+        as_numbers = [17334]
+    }
+    wait_on_complete = false
+    depends_on = [
+        akamai_gtm_domain.test_domain,
+        akamai_gtm_datacenter.test_as_datacenter
+    ]
+ 
+}`, gtm_test_domain)
+
+var asMap *gtm.AsMap
+
+func TestAccAkamaiGTMAsMap_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckAS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAkamaiGTMAsMapDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAkamaiGTMAsMapConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAkamaiGTMAsMapExists,
+					testAccCheckNumbersValues,
+					resource.TestCheckResourceAttr("akamai_gtm_asmap.test_as", "wait_on_complete", "false"),
+				),
+				//ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAkamaiGTMAsMap_update(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckAS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAkamaiGTMAsMapDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAkamaiGTMAsMapConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAkamaiGTMAsMapExists,
+					testAccCheckNumbersValues,
+					resource.TestCheckResourceAttr("akamai_gtm_asmap.test_as", "wait_on_complete", "false"),
+				),
+				//ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccAkamaiGTMAsMapUpdateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAkamaiGTMAsMapExists,
+					testAccCheckNumbersValues,
+					resource.TestCheckResourceAttr("akamai_gtm_asmap.test_as", "wait_on_complete", "false"),
+				),
+				//ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccPreCheckAS(t *testing.T) {
+
+	testAccPreCheckTF(t)
+	testCheckDeleteAsMap("test_asmap", gtm_test_domain)
+	testAccDeleteDatacenterByNickname("test_as_datacenter", gtm_test_domain)
+
+}
+
+func testCheckDeleteAsMap(asName string, dom string) error {
+
+	as, err := gtm.GetAsMap(asName, dom)
+	if as == nil {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	log.Printf("[DEBUG] [Akamai GTMv1] Deleting test asmap [%v]", asName)
+	_, err = as.Delete(dom)
+	if err != nil {
+		return fmt.Errorf("asmap was not deleted %s. Error: %s", asName, err.Error())
+	}
+	return nil
+
+}
+
+func testAccCheckAkamaiGTMAsMapDestroy(s *terraform.State) error {
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "akamai_gtm_asmap" {
+			continue
+		}
+
+		asName, dom, _ := parseStringID(rs.Primary.ID)
+		if err := testCheckDeleteAsMap(asName, dom); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func testAccCheckNumbersValues(s *terraform.State) error {
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "akamai_gtm_asmap" {
+			continue
+		}
+		if asMap == nil {
+			return fmt.Errorf("asmap was not found for as_Numbers check")
+		}
+		log.Printf("[DEBUG] [Akamai GTMV1_3] ASMAP Validating as_numbers")
+		// Walk thru all attributes
+		mapAttribs := rs.Primary.Attributes
+		assignEntries, err := strconv.Atoi(mapAttribs["assignment.#"])
+		if err != nil {
+			return fmt.Errorf("Assignments attribute was not found")
+		}
+		// Construct a list to compare
+		assignMap := make(map[int][]int)
+		for i := 0; i < assignEntries; i++ {
+			iString := strconv.Itoa(i)
+			assignBaseIndex := "assignments." + iString + "."
+			dcid, _ := strconv.Atoi(mapAttribs[assignBaseIndex+"datacenter_id"])
+			numbersEntries, _ := strconv.Atoi(mapAttribs[assignBaseIndex+"as_numbers.#"])
+			numbersMap := []int{}
+			numbersBaseIndex := assignBaseIndex + "as_numbers."
+			for j := 0; j < numbersEntries; j++ {
+				jString := strconv.Itoa(j)
+				numEntry, _ := strconv.Atoi(mapAttribs[numbersBaseIndex+jString])
+				numbersMap = append(numbersMap, numEntry)
+			}
+			assignMap[dcid] = numbersMap
+		}
+		for id, entry := range assignMap {
+			for _, rAssignment := range asMap.Assignments {
+				if id != rAssignment.DatacenterId {
+					continue
+				}
+				compares := 0
+				for _, n := range entry {
+					for _, rasn := range rAssignment.AsNumbers {
+						if rasn == int64(n) {
+							compares += 1
+							continue
+						}
+					}
+				}
+				if compares != len(entry) {
+					return fmt.Errorf("Assignments numbers mismatch")
+				}
+				log.Printf("[DEBUG] [Akamai GTMV1_3] ASMAP assignment numbers DC match [%v]", id)
+			}
+		}
+		return nil // only one
+	}
+	return fmt.Errorf("AsMap resource not found in state")
+
+}
+
+func testAccCheckAkamaiGTMAsMapExists(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "akamai_gtm_asmap" {
+			continue
+		}
+
+		asName, dom, err := parseStringID(rs.Primary.ID)
+		asMap, err = gtm.GetAsMap(asName, dom)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/akamai/resource_akamai_gtm_cidrmap.go
+++ b/akamai/resource_akamai_gtm_cidrmap.go
@@ -357,7 +357,7 @@ func populateTerraformCidrAssignmentsState(d *schema.ResourceData, cidr *gtm.Cid
 		}
 		a["datacenter_id"] = aObject.DatacenterId
 		a["nickname"] = aObject.Nickname
-		a["blocks"] = aObject.Blocks
+		a["blocks"] = reconcileTerraformLists(a["blocks"].([]interface{}), convertStringToInterfaceList(aObject.Blocks))
 		// remove object
 		delete(objectInventory, objIndex)
 	}

--- a/akamai/resource_akamai_gtm_cidrmap.go
+++ b/akamai/resource_akamai_gtm_cidrmap.go
@@ -87,6 +87,12 @@ func resourceGTMv1CidrMapCreate(d *schema.ResourceData, meta interface{}) error 
 	domain := d.Get("domain").(string)
 
 	log.Printf("[INFO] [Akamai GTM] Creating cidrMap [%s] in domain [%s]", d.Get("name").(string), domain)
+	// Make sure Default Datacenter exists
+	err := validateDefaultDC(d.Get("default_datacenter").([]interface{}), domain)
+	if err != nil {
+		return err
+	}
+
 	newCidr := populateNewCidrMapObject(d)
 	log.Printf("[DEBUG] [Akamai GTMv1] Proposed New CidrMap: [%v]", newCidr)
 	cStatus, err := newCidr.Create(domain)

--- a/akamai/resource_akamai_gtm_cidrmap_test.go
+++ b/akamai/resource_akamai_gtm_cidrmap_test.go
@@ -1,0 +1,238 @@
+package akamai
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	gtm "github.com/akamai/AkamaiOPEN-edgegrid-golang/configgtm-v1_4"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var testAccAkamaiGTMCidrMapConfig = fmt.Sprintf(`
+provider "akamai" {
+  gtm_section = "gtm"
+}
+
+locals {
+  	domain = "%s"
+}
+
+data "akamai_contract" "contract" {
+}
+
+data "akamai_group" "group" {
+}
+
+data "akamai_gtm_default_datacenter" "default_datacenter" {
+    domain = akamai_gtm_domain.test_domain.name
+    datacenter = 5400
+}
+
+resource "akamai_gtm_domain" "test_domain" {
+    name = local.domain
+    type = "weighted"
+    contract = data.akamai_contract.contract.id
+    comment =  "This is a test zone"
+    group  = data.akamai_group.group.id
+    load_imbalance_percentage = 10
+    wait_on_complete = false
+}
+
+resource "akamai_gtm_datacenter" "test_cidr_datacenter" {
+    domain = akamai_gtm_domain.test_domain.name
+    nickname = "test_cidr_datacenter"
+    wait_on_complete = false
+    default_load_object {
+        load_object = "test"
+        load_object_port = 80
+        load_servers = ["1.2.3.4", "1.2.3.5"]
+    }
+    depends_on = [
+         akamai_gtm_domain.test_domain
+    ]
+}
+
+resource "akamai_gtm_cidrmap" "test_cidr" {
+    domain = akamai_gtm_domain.test_domain.name
+    name = "test_cidrmap"
+    default_datacenter {
+        datacenter_id = data.akamai_gtm_default_datacenter.default_datacenter.datacenter_id
+        nickname = data.akamai_gtm_default_datacenter.default_datacenter.nickname
+    }
+    assignment {
+        datacenter_id = akamai_gtm_datacenter.test_cidr_datacenter.datacenter_id
+        nickname = akamai_gtm_datacenter.test_cidr_datacenter.nickname
+        blocks = ["1.2.3.9/24"]
+    }
+    wait_on_complete = false
+    depends_on = [
+        akamai_gtm_domain.test_domain,
+        akamai_gtm_datacenter.test_cidr_datacenter
+    ]
+}`, gtm_test_domain)
+
+var testAccAkamaiGTMCidrMapUpdateConfig = fmt.Sprintf(`
+provider "akamai" {
+  gtm_section = "gtm"
+}
+
+locals {
+        domain = "%s"
+}
+
+data "akamai_contract" "contract" {
+}
+
+data "akamai_group" "group" {
+}
+
+data "akamai_gtm_default_datacenter" "default_datacenter" {
+    domain = akamai_gtm_domain.test_domain.name
+    datacenter = 5400
+}
+
+resource "akamai_gtm_domain" "test_domain" {
+    name = local.domain
+    type = "weighted"
+    contract = data.akamai_contract.contract.id
+    comment =  "This is a test domain"
+    group  = data.akamai_group.group.id
+    load_imbalance_percentage = 10
+    wait_on_complete = false
+}
+
+resource "akamai_gtm_datacenter" "test_cidr_datacenter" {
+    domain = akamai_gtm_domain.test_domain.name
+    nickname = "test_cidr_datacenter"
+    wait_on_complete = false
+    default_load_object {
+        load_object = "test"
+        load_object_port = 80
+        load_servers = ["1.2.3.4", "1.2.3.5"]
+    }  
+    depends_on = [
+         akamai_gtm_domain.test_domain
+    ]    
+}  
+
+resource "akamai_gtm_cidrmap" "test_cidr" {
+    domain = akamai_gtm_domain.test_domain.name
+    name = "test_cidrmap"
+    default_datacenter {
+        datacenter_id = data.akamai_gtm_default_datacenter.default_datacenter.datacenter_id
+        nickname = data.akamai_gtm_default_datacenter.default_datacenter.nickname
+    }
+    assignment {
+        datacenter_id = akamai_gtm_datacenter.test_cidr_datacenter.datacenter_id
+        nickname = akamai_gtm_datacenter.test_cidr_datacenter.nickname
+        blocks = ["1.2.3.9/24"]
+    }
+    wait_on_complete = false
+    depends_on = [
+        akamai_gtm_domain.test_domain,
+        akamai_gtm_datacenter.test_cidr_datacenter
+    ]
+ 
+}`, gtm_test_domain)
+
+func TestAccAkamaiGTMCidrMap_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckCidr(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAkamaiGTMCidrMapDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAkamaiGTMCidrMapConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAkamaiGTMCidrMapExists,
+					resource.TestCheckResourceAttr("akamai_gtm_cidrmap.test_cidr", "wait_on_complete", "false"),
+				),
+				//ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAkamaiGTMCidrMap_update(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckCidr(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAkamaiGTMCidrMapDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAkamaiGTMCidrMapConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAkamaiGTMCidrMapExists,
+					resource.TestCheckResourceAttr("akamai_gtm_cidrmap.test_cidr", "wait_on_complete", "false"),
+				),
+				//ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccAkamaiGTMCidrMapUpdateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAkamaiGTMCidrMapExists,
+					resource.TestCheckResourceAttr("akamai_gtm_cidrmap.test_cidr", "wait_on_complete", "false"),
+				),
+				//ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccPreCheckCidr(t *testing.T) {
+
+	testAccPreCheckTF(t)
+	testCheckDeleteCidrMap("test_cidrmap", gtm_test_domain)
+	testAccDeleteDatacenterByNickname("test_cidr_datacenter", gtm_test_domain)
+
+}
+
+func testCheckDeleteCidrMap(cidrName string, dom string) error {
+
+	cidr, err := gtm.GetCidrMap(cidrName, dom)
+	if cidr == nil {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	log.Printf("[DEBUG] [Akamai GTMv1] Deleting test cidrmap [%v]", cidrName)
+	_, err = cidr.Delete(dom)
+	if err != nil {
+		return fmt.Errorf("cidrmap was not deleted %s. Error: %s", cidrName, err.Error())
+	}
+	return nil
+
+}
+
+func testAccCheckAkamaiGTMCidrMapDestroy(s *terraform.State) error {
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "akamai_gtm_cidrmap" {
+			continue
+		}
+
+		cidrName, dom, _ := parseStringID(rs.Primary.ID)
+		if err := testCheckDeleteCidrMap(cidrName, dom); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func testAccCheckAkamaiGTMCidrMapExists(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "akamai_gtm_cidrmap" {
+			continue
+		}
+
+		cidrName, dom, err := parseStringID(rs.Primary.ID)
+		_, err = gtm.GetCidrMap(cidrName, dom)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/akamai/resource_akamai_gtm_datacenter.go
+++ b/akamai/resource_akamai_gtm_datacenter.go
@@ -362,9 +362,13 @@ func populateDatacenterObject(d *schema.ResourceData, dc *gtm.Datacenter) {
 	}
 	if v, ok := d.GetOk("city"); ok {
 		dc.City = v.(string)
+	} else if d.HasChange("city") {
+		dc.City = v.(string)
 	}
 	if v, ok := d.GetOk("clone_of"); ok {
 		dc.CloneOf = v.(int)
+	} else if d.HasChange("clone_of") {
+	        dc.CloneOf = v.(int)
 	}
 	v := d.Get("cloud_server_host_header_override")
 	dc.CloudServerHostHeaderOverride = v.(bool)
@@ -372,13 +376,19 @@ func populateDatacenterObject(d *schema.ResourceData, dc *gtm.Datacenter) {
 	dc.CloudServerTargeting = v.(bool)
 	if v, ok := d.GetOk("continent"); ok {
 		dc.Continent = v.(string)
+	} else if d.HasChange("continent") {
+                dc.Continent = v.(string)
 	}
 	if v, ok := d.GetOk("country"); ok {
 		dc.Country = v.(string)
+	} else if d.HasChange("country") {
+                dc.Country = v.(string)
 	}
 	// pull apart Set
 	dloList := d.Get("default_load_object").([]interface{})
-	if dloList != nil {
+	if dloList == nil || len(dloList) == 0 {
+		dc.DefaultLoadObject = nil
+	} else {
 		dloObject := gtm.NewLoadObject()
 		for _, v := range dloList {
 			dloMap := v.(map[string]interface{})
@@ -388,8 +398,8 @@ func populateDatacenterObject(d *schema.ResourceData, dc *gtm.Datacenter) {
 				ls := make([]string, len(dloMap["load_servers"].([]interface{})))
 				for i, sl := range dloMap["load_servers"].([]interface{}) {
 					ls[i] = sl.(string)
-					dloObject.LoadServers = ls
 				}
+				dloObject.LoadServers = ls
 			}
 			dc.DefaultLoadObject = dloObject
 			break
@@ -397,9 +407,13 @@ func populateDatacenterObject(d *schema.ResourceData, dc *gtm.Datacenter) {
 	}
 	if v, ok := d.GetOk("latitude"); ok {
 		dc.Latitude = v.(float64)
+	} else if d.HasChange("latitude") {
+                dc.Latitude = v.(float64)
 	}
 	if v, ok := d.GetOk("longitude"); ok {
 		dc.Longitude = v.(float64)
+	} else if d.HasChange("longitude") {
+                dc.Longitude = v.(float64)
 	}
 	if v, ok := d.GetOk("nickname"); ok {
 		dc.Nickname = v.(string)
@@ -418,15 +432,23 @@ func populateDatacenterObject(d *schema.ResourceData, dc *gtm.Datacenter) {
 	}
 	if v, ok := d.GetOk("servermonitor_liveness_count"); ok {
 		dc.ServermonitorLivenessCount = v.(int)
+	} else if d.HasChange("servermonitor_liveness_count") {
+                dc.ServermonitorLivenessCount = v.(int)
 	}
 	if v, ok := d.GetOk("servermonitor_load_count"); ok {
 		dc.ServermonitorLoadCount = v.(int)
+	} else if d.HasChange("servermonitor_load_count") {
+                dc.ServermonitorLoadCount = v.(int)
 	}
 	if v, ok := d.GetOk("servermonitor_pool"); ok {
 		dc.ServermonitorPool = v.(string)
+	} else if d.HasChange("servermonitor_pool") {
+                dc.ServermonitorPool = v.(string)
 	}
 	if v, ok := d.GetOk("state_or_province"); ok {
 		dc.StateOrProvince = v.(string)
+	} else if d.HasChange("state_or_province") {
+	        dc.StateOrProvince = v.(string)
 	}
 }
 
@@ -442,18 +464,33 @@ func populateTerraformDCState(d *schema.ResourceData, dc *gtm.Datacenter) {
 	d.Set("cloud_server_targeting", dc.CloudServerTargeting)
 	d.Set("continent", dc.Continent)
 	d.Set("country", dc.Country)
-	dloNewList := make([]interface{}, 0)
-	if dc.DefaultLoadObject != nil {
-		if dc.DefaultLoadObject.LoadObject != "" || len(dc.DefaultLoadObject.LoadServers) != 0 || dc.DefaultLoadObject.LoadObjectPort > 0 {
-			// We can't distinguish a null object so hack to see if there are any non zero values
-			dloNew := make(map[string]interface{})
-			dloNew["load_object"] = dc.DefaultLoadObject.LoadObject
-			dloNew["load_object_port"] = dc.DefaultLoadObject.LoadObjectPort
-			dloNew["load_servers"] = dc.DefaultLoadObject.LoadServers
-			dloNewList = append(dloNewList, dloNew)
+       	dloStateList := d.Get("default_load_object").([]interface{})
+	if dloStateList == nil {
+		dloStateList = make([]interface{}, 0, 1)
+	}
+	if len(dloStateList) == 0 && dc.DefaultLoadObject != nil && (dc.DefaultLoadObject.LoadObject != "" || len(dc.DefaultLoadObject.LoadServers) != 0 || dc.DefaultLoadObject.LoadObjectPort > 0) {
+		// create MT object
+		newDLO := make(map[string]interface{}, 3)
+		newDLO["load_object"] = ""
+		newDLO["load_object_port"] = 0
+		newDLO["load_servers"] = make([]interface{}, 0, len(dc.DefaultLoadObject.LoadServers))
+                dloStateList = append(dloStateList, newDLO)
+	}	
+        for _, dloMap := range dloStateList {
+		if dc.DefaultLoadObject != nil && (dc.DefaultLoadObject.LoadObject != "" || len(dc.DefaultLoadObject.LoadServers) != 0 || dc.DefaultLoadObject.LoadObjectPort > 0) {
+                	dlo := dloMap.(map[string]interface{})
+                	dlo["load_object"] = dc.DefaultLoadObject.LoadObject
+                	dlo["load_object_port"] = dc.DefaultLoadObject.LoadObjectPort
+                	if dlo["load_servers"] != nil && len(dlo["load_servers"].([]interface{})) > 0 {
+                        	dlo["load_servers"] = reconcileTerraformLists(dlo["load_servers"].([]interface{}), convertStringToInterfaceList(dc.DefaultLoadObject.LoadServers))
+                	} else {
+                        	dlo["load_servers"] = dc.DefaultLoadObject.LoadServers
+                	}
+        	} else {
+			dloStateList = make([]interface{}, 0, 1)
 		}
 	}
-	d.Set("default_load_object", dloNewList)
+	d.Set("default_load_object", dloStateList)
 	d.Set("latitude", dc.Latitude)
 	d.Set("longitude", dc.Longitude)
 	d.Set("ping_interval", dc.PingInterval)

--- a/akamai/resource_akamai_gtm_datacenter.go
+++ b/akamai/resource_akamai_gtm_datacenter.go
@@ -368,7 +368,7 @@ func populateDatacenterObject(d *schema.ResourceData, dc *gtm.Datacenter) {
 	if v, ok := d.GetOk("clone_of"); ok {
 		dc.CloneOf = v.(int)
 	} else if d.HasChange("clone_of") {
-	        dc.CloneOf = v.(int)
+		dc.CloneOf = v.(int)
 	}
 	v := d.Get("cloud_server_host_header_override")
 	dc.CloudServerHostHeaderOverride = v.(bool)
@@ -377,12 +377,12 @@ func populateDatacenterObject(d *schema.ResourceData, dc *gtm.Datacenter) {
 	if v, ok := d.GetOk("continent"); ok {
 		dc.Continent = v.(string)
 	} else if d.HasChange("continent") {
-                dc.Continent = v.(string)
+		dc.Continent = v.(string)
 	}
 	if v, ok := d.GetOk("country"); ok {
 		dc.Country = v.(string)
 	} else if d.HasChange("country") {
-                dc.Country = v.(string)
+		dc.Country = v.(string)
 	}
 	// pull apart Set
 	dloList := d.Get("default_load_object").([]interface{})
@@ -408,12 +408,12 @@ func populateDatacenterObject(d *schema.ResourceData, dc *gtm.Datacenter) {
 	if v, ok := d.GetOk("latitude"); ok {
 		dc.Latitude = v.(float64)
 	} else if d.HasChange("latitude") {
-                dc.Latitude = v.(float64)
+		dc.Latitude = v.(float64)
 	}
 	if v, ok := d.GetOk("longitude"); ok {
 		dc.Longitude = v.(float64)
 	} else if d.HasChange("longitude") {
-                dc.Longitude = v.(float64)
+		dc.Longitude = v.(float64)
 	}
 	if v, ok := d.GetOk("nickname"); ok {
 		dc.Nickname = v.(string)
@@ -433,22 +433,22 @@ func populateDatacenterObject(d *schema.ResourceData, dc *gtm.Datacenter) {
 	if v, ok := d.GetOk("servermonitor_liveness_count"); ok {
 		dc.ServermonitorLivenessCount = v.(int)
 	} else if d.HasChange("servermonitor_liveness_count") {
-                dc.ServermonitorLivenessCount = v.(int)
+		dc.ServermonitorLivenessCount = v.(int)
 	}
 	if v, ok := d.GetOk("servermonitor_load_count"); ok {
 		dc.ServermonitorLoadCount = v.(int)
 	} else if d.HasChange("servermonitor_load_count") {
-                dc.ServermonitorLoadCount = v.(int)
+		dc.ServermonitorLoadCount = v.(int)
 	}
 	if v, ok := d.GetOk("servermonitor_pool"); ok {
 		dc.ServermonitorPool = v.(string)
 	} else if d.HasChange("servermonitor_pool") {
-                dc.ServermonitorPool = v.(string)
+		dc.ServermonitorPool = v.(string)
 	}
 	if v, ok := d.GetOk("state_or_province"); ok {
 		dc.StateOrProvince = v.(string)
 	} else if d.HasChange("state_or_province") {
-	        dc.StateOrProvince = v.(string)
+		dc.StateOrProvince = v.(string)
 	}
 }
 
@@ -464,7 +464,7 @@ func populateTerraformDCState(d *schema.ResourceData, dc *gtm.Datacenter) {
 	d.Set("cloud_server_targeting", dc.CloudServerTargeting)
 	d.Set("continent", dc.Continent)
 	d.Set("country", dc.Country)
-       	dloStateList := d.Get("default_load_object").([]interface{})
+	dloStateList := d.Get("default_load_object").([]interface{})
 	if dloStateList == nil {
 		dloStateList = make([]interface{}, 0, 1)
 	}
@@ -474,19 +474,19 @@ func populateTerraformDCState(d *schema.ResourceData, dc *gtm.Datacenter) {
 		newDLO["load_object"] = ""
 		newDLO["load_object_port"] = 0
 		newDLO["load_servers"] = make([]interface{}, 0, len(dc.DefaultLoadObject.LoadServers))
-                dloStateList = append(dloStateList, newDLO)
-	}	
-        for _, dloMap := range dloStateList {
+		dloStateList = append(dloStateList, newDLO)
+	}
+	for _, dloMap := range dloStateList {
 		if dc.DefaultLoadObject != nil && (dc.DefaultLoadObject.LoadObject != "" || len(dc.DefaultLoadObject.LoadServers) != 0 || dc.DefaultLoadObject.LoadObjectPort > 0) {
-                	dlo := dloMap.(map[string]interface{})
-                	dlo["load_object"] = dc.DefaultLoadObject.LoadObject
-                	dlo["load_object_port"] = dc.DefaultLoadObject.LoadObjectPort
-                	if dlo["load_servers"] != nil && len(dlo["load_servers"].([]interface{})) > 0 {
-                        	dlo["load_servers"] = reconcileTerraformLists(dlo["load_servers"].([]interface{}), convertStringToInterfaceList(dc.DefaultLoadObject.LoadServers))
-                	} else {
-                        	dlo["load_servers"] = dc.DefaultLoadObject.LoadServers
-                	}
-        	} else {
+			dlo := dloMap.(map[string]interface{})
+			dlo["load_object"] = dc.DefaultLoadObject.LoadObject
+			dlo["load_object_port"] = dc.DefaultLoadObject.LoadObjectPort
+			if dlo["load_servers"] != nil && len(dlo["load_servers"].([]interface{})) > 0 {
+				dlo["load_servers"] = reconcileTerraformLists(dlo["load_servers"].([]interface{}), convertStringToInterfaceList(dc.DefaultLoadObject.LoadServers))
+			} else {
+				dlo["load_servers"] = dc.DefaultLoadObject.LoadServers
+			}
+		} else {
 			dloStateList = make([]interface{}, 0, 1)
 		}
 	}

--- a/akamai/resource_akamai_gtm_domain.go
+++ b/akamai/resource_akamai_gtm_domain.go
@@ -464,12 +464,12 @@ func populateDomainObject(d *schema.ResourceData, dom *gtm.Domain) {
 	if v, ok := d.GetOk("default_ssl_client_private_key"); ok {
 		dom.DefaultSslClientPrivateKey = v.(string)
 	} else if d.HasChange("default_ssl_client_private_key") {
-                dom.DefaultSslClientPrivateKey = v.(string)
+		dom.DefaultSslClientPrivateKey = v.(string)
 	}
 	if v, ok := d.GetOk("default_error_penalty"); ok {
 		dom.DefaultErrorPenalty = v.(int)
 	} else if d.HasChange("default_error_penalty") {
-                dom.DefaultErrorPenalty = v.(int)
+		dom.DefaultErrorPenalty = v.(int)
 	}
 	if v, ok := d.GetOk("max_test_timeout"); ok {
 		dom.MaxTestTimeout = v.(float64)
@@ -508,7 +508,7 @@ func populateDomainObject(d *schema.ResourceData, dom *gtm.Domain) {
 	if v, ok := d.GetOk("default_ssl_client_certificate"); ok {
 		dom.DefaultSslClientCertificate = v.(string)
 	} else if d.HasChange("default_ssl_client_certificate") {
-                dom.DefaultSslClientCertificate = v.(string)
+		dom.DefaultSslClientCertificate = v.(string)
 	}
 	if v, ok := d.GetOk("end_user_mapping_enabled"); ok {
 		dom.EndUserMappingEnabled = v.(bool)

--- a/akamai/resource_akamai_gtm_domain.go
+++ b/akamai/resource_akamai_gtm_domain.go
@@ -420,11 +420,15 @@ func populateDomainObject(d *schema.ResourceData, dom *gtm.Domain) {
 			ls[i] = sl.(string)
 		}
 		dom.EmailNotificationList = ls
+	} else if d.HasChange("email_notification_list") {
+		dom.EmailNotificationList = make([]string, 0, 0)
 	}
 	if v, ok := d.GetOk("min_pingable_region_fraction"); ok {
 		dom.MinPingableRegionFraction = v.(float32)
 	}
 	if v, ok := d.GetOk("default_timeout_penalty"); ok {
+		dom.DefaultTimeoutPenalty = v.(int)
+	} else if d.HasChange("default_timeout_penalty") {
 		dom.DefaultTimeoutPenalty = v.(int)
 	}
 	if v, ok := d.GetOk("servermonitor_liveness_count"); ok {
@@ -459,9 +463,13 @@ func populateDomainObject(d *schema.ResourceData, dom *gtm.Domain) {
 	}
 	if v, ok := d.GetOk("default_ssl_client_private_key"); ok {
 		dom.DefaultSslClientPrivateKey = v.(string)
+	} else if d.HasChange("default_ssl_client_private_key") {
+                dom.DefaultSslClientPrivateKey = v.(string)
 	}
 	if v, ok := d.GetOk("default_error_penalty"); ok {
 		dom.DefaultErrorPenalty = v.(int)
+	} else if d.HasChange("default_error_penalty") {
+                dom.DefaultErrorPenalty = v.(int)
 	}
 	if v, ok := d.GetOk("max_test_timeout"); ok {
 		dom.MaxTestTimeout = v.(float64)
@@ -499,6 +507,8 @@ func populateDomainObject(d *schema.ResourceData, dom *gtm.Domain) {
 	}
 	if v, ok := d.GetOk("default_ssl_client_certificate"); ok {
 		dom.DefaultSslClientCertificate = v.(string)
+	} else if d.HasChange("default_ssl_client_certificate") {
+                dom.DefaultSslClientCertificate = v.(string)
 	}
 	if v, ok := d.GetOk("end_user_mapping_enabled"); ok {
 		dom.EndUserMappingEnabled = v.(bool)

--- a/akamai/resource_akamai_gtm_geomap.go
+++ b/akamai/resource_akamai_gtm_geomap.go
@@ -358,7 +358,7 @@ func populateTerraformGeoAssignmentsState(d *schema.ResourceData, geo *gtm.GeoMa
 		}
 		a["datacenter_id"] = aObject.DatacenterId
 		a["nickname"] = aObject.Nickname
-		a["countries"] = aObject.Countries
+		a["countries"] = reconcileTerraformLists(a["countries"].([]interface{}), convertStringToInterfaceList(aObject.Countries))
 		// remove object
 		delete(objectInventory, objIndex)
 	}

--- a/akamai/resource_akamai_gtm_geomap.go
+++ b/akamai/resource_akamai_gtm_geomap.go
@@ -88,6 +88,12 @@ func resourceGTMv1GeomapCreate(d *schema.ResourceData, meta interface{}) error {
 	domain := d.Get("domain").(string)
 
 	log.Printf("[INFO] [Akamai GTM] Creating geoMap [%s] in domain [%s]", d.Get("name").(string), domain)
+	// Make sure Default Datacenter exists
+	err := validateDefaultDC(d.Get("default_datacenter").([]interface{}), domain)
+	if err != nil {
+		return err
+	}
+
 	newGeo := populateNewGeoMapObject(d)
 	log.Printf("[DEBUG] [Akamai GTMv1] Proposed New GeoMap: [%v]", newGeo)
 	cStatus, err := newGeo.Create(domain)

--- a/akamai/resource_akamai_gtm_property.go
+++ b/akamai/resource_akamai_gtm_property.go
@@ -72,7 +72,7 @@ func resourceGTMv1Property() *schema.Resource {
 			"static_ttl": {
 				Type:     schema.TypeInt,
 				Optional: true,
-                                Default:  300,
+				Default:  300,
 			},
 			"static_rr_set": &schema.Schema{
 				Type:     schema.TypeList,
@@ -564,17 +564,17 @@ func populatePropertyObject(d *schema.ResourceData, prop *gtm.Property) {
 	if v, ok := d.GetOk("stickiness_bonus_percentage"); ok {
 		prop.StickinessBonusPercentage = v.(int)
 	} else if d.HasChange("stickiness_bonus_percentage") {
-                prop.StickinessBonusPercentage = v.(int)
+		prop.StickinessBonusPercentage = v.(int)
 	}
 	if v, ok := d.GetOk("stickiness_bonus_constant"); ok {
 		prop.StickinessBonusConstant = v.(int)
 	} else if d.HasChange("stickiness_bonus_constant") {
-                prop.StickinessBonusConstant = v.(int)
+		prop.StickinessBonusConstant = v.(int)
 	}
 	if v, ok := d.GetOk("health_threshold"); ok {
 		prop.HealthThreshold = v.(float64)
 	} else if d.HasChange("health_threshold") {
-                prop.HealthThreshold = v.(float64)
+		prop.HealthThreshold = v.(float64)
 	}
 	v := d.Get("ipv6")
 	prop.Ipv6 = v.(bool)
@@ -583,7 +583,7 @@ func populatePropertyObject(d *schema.ResourceData, prop *gtm.Property) {
 	if v, ok := d.GetOk("backup_ip"); ok {
 		prop.BackupIp = v.(string)
 	} else if d.HasChange("backup_ip") {
-                prop.BackupIp = v.(string)
+		prop.BackupIp = v.(string)
 	}
 	v = d.Get("balance_by_download_score")
 	prop.BalanceByDownloadScore = v.(bool)
@@ -593,17 +593,17 @@ func populatePropertyObject(d *schema.ResourceData, prop *gtm.Property) {
 	if v, ok := d.GetOk("unreachable_threshold"); ok {
 		prop.UnreachableThreshold = v.(float64)
 	} else if d.HasChange("unreachable_threshold") {
-                prop.UnreachableThreshold = v.(float64)
+		prop.UnreachableThreshold = v.(float64)
 	}
 	if v, ok := d.GetOk("min_live_fraction"); ok {
 		prop.MinLiveFraction = v.(float64)
 	} else if d.HasChange("min_live_fraction") {
-                prop.MinLiveFraction = v.(float64)
+		prop.MinLiveFraction = v.(float64)
 	}
 	if v, ok := d.GetOk("health_multiplier"); ok {
 		prop.HealthMultiplier = v.(float64)
 	} else if d.HasChange("health_multiplier") {
-                prop.HealthMultiplier = v.(float64)
+		prop.HealthMultiplier = v.(float64)
 	}
 	if v, ok := d.GetOk("dynamic_ttl"); ok {
 		prop.DynamicTTL = v.(int)
@@ -611,17 +611,17 @@ func populatePropertyObject(d *schema.ResourceData, prop *gtm.Property) {
 	if v, ok := d.GetOk("max_unreachable_penalty"); ok {
 		prop.MaxUnreachablePenalty = v.(int)
 	} else if d.HasChange("max_unreachable_penalty") {
-                prop.MaxUnreachablePenalty = v.(int)
+		prop.MaxUnreachablePenalty = v.(int)
 	}
 	if v, ok := d.GetOk("map_name"); ok {
 		prop.MapName = v.(string)
 	} else if d.HasChange("map_name") {
-                prop.MapName = v.(string)
+		prop.MapName = v.(string)
 	}
 	if v, ok := d.GetOk("handout_limit"); ok {
 		prop.HandoutLimit = v.(int)
 	} else if d.HasChange("handout_limit") {
-                prop.HandoutLimit = v.(int)
+		prop.HandoutLimit = v.(int)
 	}
 	if v, ok := d.GetOk("handout_mode"); ok {
 		prop.HandoutMode = v.(string)
@@ -629,12 +629,12 @@ func populatePropertyObject(d *schema.ResourceData, prop *gtm.Property) {
 	if v, ok := d.GetOk("load_imbalance_percentage"); ok {
 		prop.LoadImbalancePercentage = v.(float64)
 	} else if d.HasChange("load_imbalance_percentage") {
-                prop.LoadImbalancePercentage = v.(float64)
+		prop.LoadImbalancePercentage = v.(float64)
 	}
 	if v, ok := d.GetOk("failover_delay"); ok {
 		prop.FailoverDelay = v.(int)
 	} else if d.HasChange("failover_delay") {
-                prop.FailoverDelay = v.(int)
+		prop.FailoverDelay = v.(int)
 	}
 	if v, ok := d.GetOk("backup_cname"); ok {
 		prop.BackupCName = v.(string)
@@ -644,12 +644,12 @@ func populatePropertyObject(d *schema.ResourceData, prop *gtm.Property) {
 	if v, ok := d.GetOk("failback_delay"); ok {
 		prop.FailbackDelay = v.(int)
 	} else if d.HasChange("failback_delay") {
-                prop.FailbackDelay = v.(int)
+		prop.FailbackDelay = v.(int)
 	}
 	if v, ok := d.GetOk("health_max"); ok {
 		prop.HealthMax = v.(float64)
 	} else if d.HasChange("health_max") {
-                prop.HealthMax = v.(float64)
+		prop.HealthMax = v.(float64)
 	}
 	v = d.Get("ghost_demand_reporting")
 	prop.GhostDemandReporting = v.(bool)
@@ -662,12 +662,12 @@ func populatePropertyObject(d *schema.ResourceData, prop *gtm.Property) {
 	if v, ok := d.GetOk("cname"); ok {
 		prop.CName = v.(string)
 	} else if d.HasChange("cname") {
-                prop.CName = v.(string)
+		prop.CName = v.(string)
 	}
 	if v, ok := d.GetOk("comments"); ok {
 		prop.Comments = v.(string)
 	} else if d.HasChange("comments") {
-                prop.Comments = v.(string)
+		prop.Comments = v.(string)
 	}
 	populateTrafficTargetObject(d, prop)
 	populateStaticRRSetObject(d, prop)
@@ -1002,8 +1002,8 @@ func populateTerraformLivenessTestState(d *schema.ResourceData, prop *gtm.Proper
 }
 
 func convertStringToInterfaceList(stringList []string) []interface{} {
-	
-        log.Printf("[DEBUG] [Akamai GTMv1] String List: %v", stringList)
+
+	log.Printf("[DEBUG] [Akamai GTMv1] String List: %v", stringList)
 	retList := make([]interface{}, 0, len(stringList))
 	for _, v := range stringList {
 		retList = append(retList, v)
@@ -1011,29 +1011,29 @@ func convertStringToInterfaceList(stringList []string) []interface{} {
 
 	return retList
 
-} 
+}
 
 func convertIntToInterfaceList(intList []int) []interface{} {
 
-        log.Printf("[DEBUG] [Akamai GTMv1] Int List: %v", intList)
-        retList := make([]interface{}, 0, len(intList))
-        for _, v := range intList {
-                retList = append(retList, v)
-        }
+	log.Printf("[DEBUG] [Akamai GTMv1] Int List: %v", intList)
+	retList := make([]interface{}, 0, len(intList))
+	for _, v := range intList {
+		retList = append(retList, v)
+	}
 
-        return retList
+	return retList
 
 }
 
 func convertInt64ToInterfaceList(intList []int64) []interface{} {
 
-        log.Printf("[DEBUG] [Akamai GTMv1] Int List: %v", intList)
-        retList := make([]interface{}, 0, len(intList))
-        for _, v := range intList {
-                retList = append(retList, v)
-        }
+	log.Printf("[DEBUG] [Akamai GTMv1] Int List: %v", intList)
+	retList := make([]interface{}, 0, len(intList))
+	for _, v := range intList {
+		retList = append(retList, v)
+	}
 
-        return retList
+	return retList
 
 }
 
@@ -1041,7 +1041,7 @@ func convertInt64ToInterfaceList(intList []int64) []interface{} {
 func reconcileTerraformLists(terraList []interface{}, newList []interface{}) []interface{} {
 
 	log.Printf("[DEBUG] [Akamai GTMv1] Existing Terra List: %v", terraList)
-        log.Printf("[DEBUG] [Akamai GTMv1] Read List: %v", newList)
+	log.Printf("[DEBUG] [Akamai GTMv1] Read List: %v", newList)
 	newMap := make(map[string]interface{}, len(newList))
 	updatedList := make([]interface{}, 0, len(newList))
 	for _, newelem := range newList {
@@ -1059,7 +1059,7 @@ func reconcileTerraformLists(terraList []interface{}, newList []interface{}) []i
 		updatedList = append(updatedList, newVal)
 	}
 
-        log.Printf("[DEBUG] [Akamai GTMv1] Updated Terra List: %v", updatedList)
+	log.Printf("[DEBUG] [Akamai GTMv1] Updated Terra List: %v", updatedList)
 	return updatedList
 
-} 
+}

--- a/akamai/resource_akamai_gtm_property.go
+++ b/akamai/resource_akamai_gtm_property.go
@@ -72,6 +72,7 @@ func resourceGTMv1Property() *schema.Resource {
 			"static_ttl": {
 				Type:     schema.TypeInt,
 				Optional: true,
+                                Default:  300,
 			},
 			"static_rr_set": &schema.Schema{
 				Type:     schema.TypeList,
@@ -562,12 +563,18 @@ func populatePropertyObject(d *schema.ResourceData, prop *gtm.Property) {
 	}
 	if v, ok := d.GetOk("stickiness_bonus_percentage"); ok {
 		prop.StickinessBonusPercentage = v.(int)
+	} else if d.HasChange("stickiness_bonus_percentage") {
+                prop.StickinessBonusPercentage = v.(int)
 	}
 	if v, ok := d.GetOk("stickiness_bonus_constant"); ok {
 		prop.StickinessBonusConstant = v.(int)
+	} else if d.HasChange("stickiness_bonus_constant") {
+                prop.StickinessBonusConstant = v.(int)
 	}
 	if v, ok := d.GetOk("health_threshold"); ok {
 		prop.HealthThreshold = v.(float64)
+	} else if d.HasChange("health_threshold") {
+                prop.HealthThreshold = v.(float64)
 	}
 	v := d.Get("ipv6")
 	prop.Ipv6 = v.(bool)
@@ -575,6 +582,8 @@ func populatePropertyObject(d *schema.ResourceData, prop *gtm.Property) {
 	prop.UseComputedTargets = v.(bool)
 	if v, ok := d.GetOk("backup_ip"); ok {
 		prop.BackupIp = v.(string)
+	} else if d.HasChange("backup_ip") {
+                prop.BackupIp = v.(string)
 	}
 	v = d.Get("balance_by_download_score")
 	prop.BalanceByDownloadScore = v.(bool)
@@ -583,42 +592,64 @@ func populatePropertyObject(d *schema.ResourceData, prop *gtm.Property) {
 	}
 	if v, ok := d.GetOk("unreachable_threshold"); ok {
 		prop.UnreachableThreshold = v.(float64)
+	} else if d.HasChange("unreachable_threshold") {
+                prop.UnreachableThreshold = v.(float64)
 	}
 	if v, ok := d.GetOk("min_live_fraction"); ok {
 		prop.MinLiveFraction = v.(float64)
+	} else if d.HasChange("min_live_fraction") {
+                prop.MinLiveFraction = v.(float64)
 	}
 	if v, ok := d.GetOk("health_multiplier"); ok {
 		prop.HealthMultiplier = v.(float64)
+	} else if d.HasChange("health_multiplier") {
+                prop.HealthMultiplier = v.(float64)
 	}
 	if v, ok := d.GetOk("dynamic_ttl"); ok {
 		prop.DynamicTTL = v.(int)
 	}
 	if v, ok := d.GetOk("max_unreachable_penalty"); ok {
 		prop.MaxUnreachablePenalty = v.(int)
+	} else if d.HasChange("max_unreachable_penalty") {
+                prop.MaxUnreachablePenalty = v.(int)
 	}
 	if v, ok := d.GetOk("map_name"); ok {
 		prop.MapName = v.(string)
+	} else if d.HasChange("map_name") {
+                prop.MapName = v.(string)
 	}
 	if v, ok := d.GetOk("handout_limit"); ok {
 		prop.HandoutLimit = v.(int)
+	} else if d.HasChange("handout_limit") {
+                prop.HandoutLimit = v.(int)
 	}
 	if v, ok := d.GetOk("handout_mode"); ok {
 		prop.HandoutMode = v.(string)
 	}
 	if v, ok := d.GetOk("load_imbalance_percentage"); ok {
 		prop.LoadImbalancePercentage = v.(float64)
+	} else if d.HasChange("load_imbalance_percentage") {
+                prop.LoadImbalancePercentage = v.(float64)
 	}
 	if v, ok := d.GetOk("failover_delay"); ok {
 		prop.FailoverDelay = v.(int)
+	} else if d.HasChange("failover_delay") {
+                prop.FailoverDelay = v.(int)
 	}
 	if v, ok := d.GetOk("backup_cname"); ok {
+		prop.BackupCName = v.(string)
+	} else if d.HasChange("backup_cname") {
 		prop.BackupCName = v.(string)
 	}
 	if v, ok := d.GetOk("failback_delay"); ok {
 		prop.FailbackDelay = v.(int)
+	} else if d.HasChange("failback_delay") {
+                prop.FailbackDelay = v.(int)
 	}
 	if v, ok := d.GetOk("health_max"); ok {
 		prop.HealthMax = v.(float64)
+	} else if d.HasChange("health_max") {
+                prop.HealthMax = v.(float64)
 	}
 	v = d.Get("ghost_demand_reporting")
 	prop.GhostDemandReporting = v.(bool)
@@ -630,9 +661,13 @@ func populatePropertyObject(d *schema.ResourceData, prop *gtm.Property) {
 	}
 	if v, ok := d.GetOk("cname"); ok {
 		prop.CName = v.(string)
+	} else if d.HasChange("cname") {
+                prop.CName = v.(string)
 	}
 	if v, ok := d.GetOk("comments"); ok {
 		prop.Comments = v.(string)
+	} else if d.HasChange("comments") {
+                prop.Comments = v.(string)
 	}
 	populateTrafficTargetObject(d, prop)
 	populateStaticRRSetObject(d, prop)
@@ -731,7 +766,7 @@ func populateTerraformTrafficTargetState(d *schema.ResourceData, prop *gtm.Prope
 		tt["enabled"] = ttObject.Enabled
 		tt["weight"] = ttObject.Weight
 		tt["handout_cname"] = ttObject.HandoutCName
-		tt["servers"] = ttObject.Servers
+		tt["servers"] = reconcileTerraformLists(tt["servers"].([]interface{}), convertStringToInterfaceList(ttObject.Servers))
 		// remove object
 		delete(objectInventory, objIndex)
 	}
@@ -799,7 +834,7 @@ func populateTerraformStaticRRSetState(d *schema.ResourceData, prop *gtm.Propert
 		}
 		rr["type"] = rrObject.Type
 		rr["ttl"] = rrObject.TTL
-		rr["rdata"] = rrObject.Rdata
+		rr["rdata"] = reconcileTerraformLists(rr["rdata"].([]interface{}), convertStringToInterfaceList(rrObject.Rdata))
 		// remove object
 		delete(objectInventory, objIndex)
 	}
@@ -965,3 +1000,66 @@ func populateTerraformLivenessTestState(d *schema.ResourceData, prop *gtm.Proper
 	d.Set("liveness_test", ltStateList)
 
 }
+
+func convertStringToInterfaceList(stringList []string) []interface{} {
+	
+        log.Printf("[DEBUG] [Akamai GTMv1] String List: %v", stringList)
+	retList := make([]interface{}, 0, len(stringList))
+	for _, v := range stringList {
+		retList = append(retList, v)
+	}
+
+	return retList
+
+} 
+
+func convertIntToInterfaceList(intList []int) []interface{} {
+
+        log.Printf("[DEBUG] [Akamai GTMv1] Int List: %v", intList)
+        retList := make([]interface{}, 0, len(intList))
+        for _, v := range intList {
+                retList = append(retList, v)
+        }
+
+        return retList
+
+}
+
+func convertInt64ToInterfaceList(intList []int64) []interface{} {
+
+        log.Printf("[DEBUG] [Akamai GTMv1] Int List: %v", intList)
+        retList := make([]interface{}, 0, len(intList))
+        for _, v := range intList {
+                retList = append(retList, v)
+        }
+
+        return retList
+
+}
+
+// Util method to reconcile list configs. Type agnostic. Goal: maintain order of tf list config
+func reconcileTerraformLists(terraList []interface{}, newList []interface{}) []interface{} {
+
+	log.Printf("[DEBUG] [Akamai GTMv1] Existing Terra List: %v", terraList)
+        log.Printf("[DEBUG] [Akamai GTMv1] Read List: %v", newList)
+	newMap := make(map[string]interface{}, len(newList))
+	updatedList := make([]interface{}, 0, len(newList))
+	for _, newelem := range newList {
+		newMap[fmt.Sprintf("%v", newelem)] = newelem
+	}
+	// walk existing terra list and check new.
+	for _, v := range terraList {
+		vindex := fmt.Sprintf("%v", v)
+		if _, ok := newMap[vindex]; ok {
+			updatedList = append(updatedList, v)
+			delete(newMap, vindex)
+		}
+	}
+	for _, newVal := range newMap {
+		updatedList = append(updatedList, newVal)
+	}
+
+        log.Printf("[DEBUG] [Akamai GTMv1] Updated Terra List: %v", updatedList)
+	return updatedList
+
+} 

--- a/akamai/resource_akamai_gtm_property_test.go
+++ b/akamai/resource_akamai_gtm_property_test.go
@@ -38,7 +38,7 @@ resource "akamai_gtm_domain" "test_domain" {
 
 resource "akamai_gtm_datacenter" "test_prop_datacenter" {
     domain = akamai_gtm_domain.test_domain.name
-    nickname = "test_prop_datacenter1"
+    nickname = "test_prop_datacenter"
     wait_on_complete = false
     default_load_object {
         load_object = "test"
@@ -245,7 +245,12 @@ func testCheckDeleteProperty(propName string, dom string) error {
 		return nil
 	}
 	if err != nil {
-		return err
+		_, ok := err.(gtm.CommonError)
+		if ok {
+			return nil
+		} else {
+			return err
+		}
 	}
 	log.Printf("[DEBUG] [Akamai GTMv1] Deleting test property [%v]", propName)
 	_, err = prop.Delete(dom)

--- a/akamai/resource_akamai_gtm_resource.go
+++ b/akamai/resource_akamai_gtm_resource.go
@@ -327,37 +327,58 @@ func populateResourceObject(d *schema.ResourceData, rsrc *gtm.Resource) {
 	}
 	if v, ok := d.GetOk("host_header"); ok {
 		rsrc.HostHeader = v.(string)
+	} else if d.HasChange("host_header") {
+                rsrc.HostHeader = v.(string)
 	}
 	if v, ok := d.GetOk("least_squares_decay"); ok {
 		rsrc.LeastSquaresDecay = v.(float64)
+	} else if d.HasChange("least_squares_decay") {
+                rsrc.LeastSquaresDecay = v.(float64)
 	}
 	if v, ok := d.GetOk("upper_bound"); ok {
 		rsrc.UpperBound = v.(int)
+	} else if d.HasChange("upper_bound") {
+                rsrc.UpperBound = v.(int)
 	}
 	if v, ok := d.GetOk("description"); ok {
 		rsrc.Description = v.(string)
+	} else if d.HasChange("description") {
+                rsrc.Description = v.(string)
 	}
 	if v, ok := d.GetOk("leader_string"); ok {
 		rsrc.LeaderString = v.(string)
+	} else if d.HasChange("leader_string") {
+                rsrc.LeaderString = v.(string)
 	}
 	if v, ok := d.GetOk("constrained_property"); ok {
 		rsrc.ConstrainedProperty = v.(string)
+	} else if d.HasChange("constrained_property") {
+                rsrc.ConstrainedProperty = v.(string)
 	}
 	if v, ok := d.GetOk("aggregation_type"); ok {
 		rsrc.AggregationType = v.(string)
 	}
 	if v, ok := d.GetOk("load_imbalance_percentage"); ok {
 		rsrc.LoadImbalancePercentage = v.(float64)
+	} else if d.HasChange("load_imbalance_percentage") {
+                rsrc.LoadImbalancePercentage = v.(float64)
 	}
 	if v, ok := d.GetOk("max_u_multiplicative_increment"); ok {
 		rsrc.MaxUMultiplicativeIncrement = v.(float64)
+	} else if d.HasChange("max_u_multiplicative_increment") {
+                rsrc.MaxUMultiplicativeIncrement = v.(float64)
 	}
 	if v, ok := d.GetOk("decay_rate"); ok {
 		rsrc.DecayRate = v.(float64)
+	} else if d.HasChange("decay_rate") {
+                rsrc.DecayRate = v.(float64)
 	}
 	if _, ok := d.GetOk("resource_instance"); ok {
 		populateResourceInstancesObject(d, rsrc)
+	} else if d.HasChange("resource_instance") {
+		rsrc.ResourceInstances = make([]*gtm.ResourceInstance, 0)		
 	}
+
 	return
 
 }
@@ -432,7 +453,11 @@ func populateTerraformResourceInstancesState(d *schema.ResourceData, rsrc *gtm.R
 		ri["use_default_load_object"] = riObject.UseDefaultLoadObject
 		ri["load_object"] = riObject.LoadObject.LoadObject
 		ri["load_object_port"] = riObject.LoadObjectPort
-		ri["load_servers"] = riObject.LoadServers
+		if ri["load_servers"] != nil {
+			ri["load_servers"] = reconcileTerraformLists(ri["load_servers"].([]interface{}), convertStringToInterfaceList(riObject.LoadServers))
+		} else {
+			ri["load_servers"] = riObject.LoadServers
+		}
 		// remove object
 		delete(riObjectInventory, objIndex)
 	}

--- a/akamai/resource_akamai_gtm_resource.go
+++ b/akamai/resource_akamai_gtm_resource.go
@@ -328,32 +328,32 @@ func populateResourceObject(d *schema.ResourceData, rsrc *gtm.Resource) {
 	if v, ok := d.GetOk("host_header"); ok {
 		rsrc.HostHeader = v.(string)
 	} else if d.HasChange("host_header") {
-                rsrc.HostHeader = v.(string)
+		rsrc.HostHeader = v.(string)
 	}
 	if v, ok := d.GetOk("least_squares_decay"); ok {
 		rsrc.LeastSquaresDecay = v.(float64)
 	} else if d.HasChange("least_squares_decay") {
-                rsrc.LeastSquaresDecay = v.(float64)
+		rsrc.LeastSquaresDecay = v.(float64)
 	}
 	if v, ok := d.GetOk("upper_bound"); ok {
 		rsrc.UpperBound = v.(int)
 	} else if d.HasChange("upper_bound") {
-                rsrc.UpperBound = v.(int)
+		rsrc.UpperBound = v.(int)
 	}
 	if v, ok := d.GetOk("description"); ok {
 		rsrc.Description = v.(string)
 	} else if d.HasChange("description") {
-                rsrc.Description = v.(string)
+		rsrc.Description = v.(string)
 	}
 	if v, ok := d.GetOk("leader_string"); ok {
 		rsrc.LeaderString = v.(string)
 	} else if d.HasChange("leader_string") {
-                rsrc.LeaderString = v.(string)
+		rsrc.LeaderString = v.(string)
 	}
 	if v, ok := d.GetOk("constrained_property"); ok {
 		rsrc.ConstrainedProperty = v.(string)
 	} else if d.HasChange("constrained_property") {
-                rsrc.ConstrainedProperty = v.(string)
+		rsrc.ConstrainedProperty = v.(string)
 	}
 	if v, ok := d.GetOk("aggregation_type"); ok {
 		rsrc.AggregationType = v.(string)
@@ -361,22 +361,22 @@ func populateResourceObject(d *schema.ResourceData, rsrc *gtm.Resource) {
 	if v, ok := d.GetOk("load_imbalance_percentage"); ok {
 		rsrc.LoadImbalancePercentage = v.(float64)
 	} else if d.HasChange("load_imbalance_percentage") {
-                rsrc.LoadImbalancePercentage = v.(float64)
+		rsrc.LoadImbalancePercentage = v.(float64)
 	}
 	if v, ok := d.GetOk("max_u_multiplicative_increment"); ok {
 		rsrc.MaxUMultiplicativeIncrement = v.(float64)
 	} else if d.HasChange("max_u_multiplicative_increment") {
-                rsrc.MaxUMultiplicativeIncrement = v.(float64)
+		rsrc.MaxUMultiplicativeIncrement = v.(float64)
 	}
 	if v, ok := d.GetOk("decay_rate"); ok {
 		rsrc.DecayRate = v.(float64)
 	} else if d.HasChange("decay_rate") {
-                rsrc.DecayRate = v.(float64)
+		rsrc.DecayRate = v.(float64)
 	}
 	if _, ok := d.GetOk("resource_instance"); ok {
 		populateResourceInstancesObject(d, rsrc)
 	} else if d.HasChange("resource_instance") {
-		rsrc.ResourceInstances = make([]*gtm.ResourceInstance, 0)		
+		rsrc.ResourceInstances = make([]*gtm.ResourceInstance, 0)
 	}
 
 	return

--- a/go.mod
+++ b/go.mod
@@ -21,4 +21,4 @@ replace (
 	sourcegraph.com/sourcegraph/go-diff => github.com/sourcegraph/go-diff v0.5.1
 )
 
-go 1.13
+go 1.11

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-akamai
 
 require (
-	github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.11
+	github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.13
 	github.com/go-ini/ini v1.52.0 // indirect
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce // indirect
 	github.com/hashicorp/terraform v0.12.3

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-akamai
 
 require (
-	github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.10
+	github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.11
 	github.com/go-ini/ini v1.52.0 // indirect
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce // indirect
 	github.com/hashicorp/terraform v0.12.3

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,10 @@ github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.10 h1:WcJnISZ8/jX/+Jkiyfsy3AH4
 github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.10/go.mod h1:L+HB2uBoDgi3+r1pJEJcbGwyyHhd2QXaGsKLbDwtm8Q=
 github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.11 h1:QGjNHMwoPYxE5NpOAc8kpd2KTY293/oFk5BWdjkza+k=
 github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.11/go.mod h1:L+HB2uBoDgi3+r1pJEJcbGwyyHhd2QXaGsKLbDwtm8Q=
+github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.12 h1:MJM/RNvNNJd8NHpI/KpU2aPZbtpKwOHwIMo5he4h+io=
+github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.12/go.mod h1:L+HB2uBoDgi3+r1pJEJcbGwyyHhd2QXaGsKLbDwtm8Q=
+github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.13 h1:4TBWOJynmCczvd3Z+wldGFoIdpmvwLI92uPtU8KFH+c=
+github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.13/go.mod h1:L+HB2uBoDgi3+r1pJEJcbGwyyHhd2QXaGsKLbDwtm8Q=
 github.com/akamai/terraform-provider-akamai v0.0.0-20190627162730-30bcc4ef7369 h1:y2z7/2O5D54+pgYiHoxbLkEgNW/V+Zxt6kibb9dWmxQ=
 github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190329064014-6e358769c32a h1:APorzFpCcv6wtD5vmRWYqNm4N55kbepL7c7kTq9XI6A=
 github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190329064014-6e358769c32a/go.mod h1:T9M45xf79ahXVelWoOBmH0y4aC1t5kXO5BxwyakgIGA=

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.9 h1:NhBAVF3E0IcOz+Hpue0emRYC1
 github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.9/go.mod h1:L+HB2uBoDgi3+r1pJEJcbGwyyHhd2QXaGsKLbDwtm8Q=
 github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.10 h1:WcJnISZ8/jX/+Jkiyfsy3AH4CFQeP6/wZQLASiKq+HU=
 github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.10/go.mod h1:L+HB2uBoDgi3+r1pJEJcbGwyyHhd2QXaGsKLbDwtm8Q=
+github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.11 h1:QGjNHMwoPYxE5NpOAc8kpd2KTY293/oFk5BWdjkza+k=
+github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.11/go.mod h1:L+HB2uBoDgi3+r1pJEJcbGwyyHhd2QXaGsKLbDwtm8Q=
 github.com/akamai/terraform-provider-akamai v0.0.0-20190627162730-30bcc4ef7369 h1:y2z7/2O5D54+pgYiHoxbLkEgNW/V+Zxt6kibb9dWmxQ=
 github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190329064014-6e358769c32a h1:APorzFpCcv6wtD5vmRWYqNm4N55kbepL7c7kTq9XI6A=
 github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190329064014-6e358769c32a/go.mod h1:T9M45xf79ahXVelWoOBmH0y4aC1t5kXO5BxwyakgIGA=

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/.travis.yml
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/.travis.yml
@@ -1,37 +1,36 @@
 language: go
 sudo: false
-go:
-  - 1.6
-  - 1.7
-  - 1.8
-  - 1.9
-  - "1.10"
-  - "1.11.x"
-  - tip
-env:
-  # Install dependencies based on the glide.lock
-  #- DEPS=''
-  # Upgrade to the latest dependencies
-  #- DEPS='-update'
-  - GO111MODULE=on
+
+# Fix patching for forks
+go_import_path: github.com/akamai/AkamaiOPEN-edgegrid-golang
+
+cache:
+  directories:
+    - $GOPATH/pkg/mod
+
 matrix:
   fast_finish: true
+  include:
+    - go: 1.12.x
+    - go: 1.13.x
+    - go: 1.x
+    - go: tip
   allow_failures:
-  # Allow Go 1.6, and tip to fail, as well as whenever we use upgraded dependencies
-  - go: 1.6
-  - go: 1.7
-  - go: 1.8
-  - go: tip
-  - env: DEPS='-update'
-before_install:
-  # Fix pathing for forks
-  - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-  - mkdir -p $HOME/gopath/src/github.com/akamai/AkamaiOPEN-edgegrid-golang
-  - rsync -az ${TRAVIS_BUILD_DIR}/ $HOME/gopath/src/github.com/akamai/AkamaiOPEN-edgegrid-golang/
-  - export TRAVIS_BUILD_DIR=$HOME/gopath/src/github.com/akamai/AkamaiOPEN-edgegrid-golang
-  - cd $HOME/gopath/src/github.com/akamai/AkamaiOPEN-edgegrid-golang
+    - go: tip
+
+env:
+  global:
+    - GO111MODULE=on
+
+install:
+  - go mod tidy
+  - git diff --exit-code go.mod
+  - git diff --exit-code go.sum
+  - go mod download
+
 script:
-  - ls -d */ | grep -vE '(examples|testdata|vendor)' | xargs -I {package} go test -v ./{package}
+  - go test -v ./...
+
 notifications:
   slack:
     secure: sf5CrgPZ2UjTmGFg1hbSdEB3GXyBybeoZQDOI/pk1ywId4mjN1HgAFooDaZx9Qn+orhdQny3jMcdx1qyLe9YtV7WhIRGRQWgJiZ7H+6YRCWYNnSopsSDJ91Q/PaQrgsPSIHL+vfSkyW9iDXrT09SK0IOlWHTrrYMcJiiOCkx2QZgIBMASXWzCRFMSxfqDBuZ8FuNMhcYTIEz4xBLO7seAl9+FvQTzpSXXyEwoKeZjLx2J2+9J1onx9ccnb5ioPeICRuiIKlSvu7VfFkDgc8k8luoktKSG+ZRpwcdae8VoQCzyt7OPzI1kSoZZw20gp2oYQcRkwpLBM007JkW2+KQraF5tZ9Ok8C1vG97lsByhd23r022joyTGpD+TZqWfXUX7K461GJJpohWoFlHshOaAwNj37XWKD8REpb0Qj7vABIfH+gXQhlJHBRCfKMRf12ILzU2yUbbQftwcPkcivNHGknEAkHIjWKk5lDH9uC2is5nWJHDCt/h/xa/AfvNbt28Kol+8yexRypnmorTzG9CBHq+pKrm48cBEGUxREiUjN7v5RGgJH+DB5nKkV4nH3P7mvWV+mkDcAXZPhDprplFl1Q7YV56OyjAY+dlpY6xyGopDz9DmmZifqLxR6mP9eSCIeIM9VsDJUwhfnnwyxRuuzZWFa+Adu8kuaBR8RqjcdE=

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/README.md
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/README.md
@@ -9,14 +9,6 @@ This library implements an Authentication handler for [net/http](https://golang.
 that provides the [Akamai OPEN Edgegrid Authentication](https://developer.akamai.com/introduction/Client_Auth.html) 
 scheme. For more information visit the [Akamai OPEN Developer Community](https://developer.akamai.com).
 
-## Installation
-
-This package uses `dep` to manage to dependencies and installation. To install `dep`, see the [`dep` install documentation](https://github.com/golang/dep#installation)
-
-```bash
-$ dep ensure -add github.com/akamai/AkamaiOPEN-edgegrid-golang
-```
-
 ## Usage
 
 GET Example:

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1/errors.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1/errors.go
@@ -65,7 +65,7 @@ func NewAPIError(response *http.Response) APIError {
 // other purposes.
 func NewAPIErrorFromBody(response *http.Response, body []byte) APIError {
 	error := APIError{}
-	if err := jsonhooks.Unmarshal(body, &error); err == nil {
+	if err := jsonhooks.Unmarshal(body, &error); err != nil {
 		error.Status = response.StatusCode
 		error.Title = response.Status
 	}

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/errors.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/errors.go
@@ -123,3 +123,55 @@ func (e *RecordError) Error() string {
 
 	return "<nil>"
 }
+
+type TsigError struct {
+	keyName          string
+	httpErrorMessage string
+	apiErrorMessage  string
+	err              error
+}
+
+func (e *TsigError) Network() bool {
+	if e.httpErrorMessage != "" {
+		return true
+	}
+	return false
+}
+
+func (e *TsigError) NotFound() bool {
+	if e.err == nil && e.httpErrorMessage == "" && e.apiErrorMessage == "" {
+		return true
+	}
+	return false
+}
+
+func (e *TsigError) FailedToSave() bool {
+	return false
+}
+
+func (e *TsigError) ValidationFailed() bool {
+	if e.apiErrorMessage != "" {
+		return true
+	}
+	return false
+}
+
+func (e *TsigError) Error() string {
+	if e.Network() {
+		return fmt.Sprintf("Tsig network error: [%s]", e.httpErrorMessage)
+	}
+
+	if e.NotFound() {
+		return fmt.Sprintf("tsig key not found.")
+	}
+
+	if e.FailedToSave() {
+		return fmt.Sprintf("tsig key failed to save: [%s]", e.err.Error())
+	}
+
+	if e.ValidationFailed() {
+		return fmt.Sprintf("tsig key validation failed: [%s]", e.apiErrorMessage)
+	}
+
+	return "<nil>"
+}

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/errors.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/errors.go
@@ -2,6 +2,7 @@ package dnsv2
 
 import (
 	"fmt"
+	client "github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
 )
 
 type ConfigDNSError interface {
@@ -76,6 +77,7 @@ func (e *ZoneError) Error() string {
 type RecordError struct {
 	fieldName        string
 	httpErrorMessage string
+        apiErrorMessage  string
 	err              error
 }
 
@@ -87,7 +89,10 @@ func (e *RecordError) Network() bool {
 }
 
 func (e *RecordError) NotFound() bool {
-	return false
+        if e.err == nil && e.httpErrorMessage == "" && e.apiErrorMessage == "" {
+                return true
+        }
+        return false
 }
 
 func (e *RecordError) FailedToSave() bool {
@@ -98,16 +103,40 @@ func (e *RecordError) FailedToSave() bool {
 }
 
 func (e *RecordError) ValidationFailed() bool {
-	if e.fieldName != "" {
+	if e.fieldName != "" && e.err == nil {
 		return true
 	}
 	return false
+}
+
+func (e *RecordError) ConcurrencyConflict() bool {
+	_, ok := e.err.(client.APIError)
+	if ok && e.err.(client.APIError).Status == 409 {
+		return true
+	}
+	return false 
+}
+
+func (e *RecordError) BadRequest() bool {
+        _, ok := e.err.(client.APIError)
+        if ok && e.err.(client.APIError).Status == 400 {
+                return true
+        }
+        return false
 }
 
 func (e *RecordError) Error() string {
 	if e.Network() {
 		return fmt.Sprintf("Record network error: [%s]", e.httpErrorMessage)
 	}
+
+	if e.ConcurrencyConflict() {
+		return fmt.Sprintf("Modification Confict: [%s]", e.apiErrorMessage)
+	} 
+
+        if e.BadRequest() {
+                return fmt.Sprintf("Invalid Operation: [%s]", e.apiErrorMessage)
+        }       
 
 	if e.NotFound() {
 		return fmt.Sprintf("Record not found.")
@@ -119,6 +148,10 @@ func (e *RecordError) Error() string {
 
 	if e.ValidationFailed() {
 		return fmt.Sprintf("Record validation failed for field [%s]", e.fieldName)
+	}
+
+	if e.err != nil {
+		return fmt.Sprintf("%s", e.err.Error())
 	}
 
 	return "<nil>"

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/fulltest
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/fulltest
@@ -1,0 +1,131 @@
+=== RUN   TestRecord_ContainsHelper
+--- PASS: TestRecord_ContainsHelper (0.00s)
+=== RUN   TestRecord_ARecord
+--- PASS: TestRecord_ARecord (0.00s)
+=== RUN   TestRecord_AllRecords_WrongTypes
+--- PASS: TestRecord_AllRecords_WrongTypes (0.00s)
+=== RUN   TestGetZoneSimple
+--- PASS: TestGetZoneSimple (0.00s)
+=== RUN   TestGetZoneRecords
+=== RUN   TestGetZoneRecords/A_Records
+Record Type A
+true
+arecord
+&{example.com  []  false  {  }    0     }
+&{{true 1} [{arecord A 3700 [10.0.0.2 10.0.0.3 1.2.3.9]}]}
+=== RUN   TestGetZoneRecords/AAAA_Records
+Record Type AAAA
+true
+ipv6record.akavaiodeveloper.net
+=== RUN   TestGetZoneRecords/AFSDB_Records
+Record Type AFSDB
+true
+afsdb.akavaiodeveloper.net
+=== RUN   TestGetZoneRecords/CNAME_Records
+Record Type CNAME
+true
+www.akavaiodeveloper.net
+=== RUN   TestGetZoneRecords/DNSKEY_Records
+Record Type DNSKEY
+true
+dnskey.akavaiodeveloper.net
+=== RUN   TestGetZoneRecords/DS_Records
+Record Type DS
+true
+ds.akavaiodeveloper.net
+=== RUN   TestGetZoneRecords/HINFO_Records
+Record Type HINFO
+true
+hinfo.akavaiodeveloper.net
+=== RUN   TestGetZoneRecords/LOC_Records
+Record Type LOC
+true
+afsdb.akavaiodeveloper.net
+=== RUN   TestGetZoneRecords/MX_Records
+Record Type MX
+true
+akavaiodeveloper.net
+=== RUN   TestGetZoneRecords/NAPTR_Records
+Record Type NAPTR
+true
+naptrrecord.akavaiodeveloper.net
+=== RUN   TestGetZoneRecords/NS_Records
+Record Type NS
+true
+akavaiodeveloper.net
+=== RUN   TestGetZoneRecords/NSEC3_Records
+Record Type NSEC3
+true
+qdeo8lqu4l81uo67oolpo9h0nv9l13dh.akavaiodeveloper.net
+=== RUN   TestGetZoneRecords/NSEC3PARAM_Records
+Record Type NSEC3PARAM
+true
+qnsec3param.akavaiodeveloper.net
+=== RUN   TestGetZoneRecords/PTR_Records
+Record Type PTR
+true
+ptr.akavaiodeveloper.net
+=== RUN   TestGetZoneRecords/RP_Records
+Record Type RP
+false
+rp.akavaiodeveloper.net
+=== RUN   TestGetZoneRecords/RRSIG_Records
+Record Type RRSIG
+true
+arecord
+=== RUN   TestGetZoneRecords/SPF_Records
+Record Type SPF
+true
+afsdb.akavaiodeveloper.net
+=== RUN   TestGetZoneRecords/SSHFP_Records
+Record Type SSHFP
+true
+afsdb.akavaiodeveloper.net
+=== RUN   TestGetZoneRecords/SRV_Records
+Record Type SRV
+true
+srv.akavaiodeveloper.net
+=== RUN   TestGetZoneRecords/TXT_Records
+Record Type TXT
+true
+text.akavaiodeveloper.net
+--- PASS: TestGetZoneRecords (0.01s)
+    --- PASS: TestGetZoneRecords/A_Records (0.00s)
+    --- PASS: TestGetZoneRecords/AAAA_Records (0.00s)
+    --- PASS: TestGetZoneRecords/AFSDB_Records (0.00s)
+    --- PASS: TestGetZoneRecords/CNAME_Records (0.00s)
+    --- PASS: TestGetZoneRecords/DNSKEY_Records (0.00s)
+    --- PASS: TestGetZoneRecords/DS_Records (0.00s)
+    --- PASS: TestGetZoneRecords/HINFO_Records (0.00s)
+    --- PASS: TestGetZoneRecords/LOC_Records (0.00s)
+    --- PASS: TestGetZoneRecords/MX_Records (0.00s)
+    --- PASS: TestGetZoneRecords/NAPTR_Records (0.00s)
+    --- PASS: TestGetZoneRecords/NS_Records (0.00s)
+    --- PASS: TestGetZoneRecords/NSEC3_Records (0.00s)
+    --- PASS: TestGetZoneRecords/NSEC3PARAM_Records (0.00s)
+    --- PASS: TestGetZoneRecords/PTR_Records (0.00s)
+    --- PASS: TestGetZoneRecords/RP_Records (0.00s)
+    --- PASS: TestGetZoneRecords/RRSIG_Records (0.00s)
+    --- PASS: TestGetZoneRecords/SPF_Records (0.00s)
+    --- PASS: TestGetZoneRecords/SSHFP_Records (0.00s)
+    --- PASS: TestGetZoneRecords/SRV_Records (0.00s)
+    --- PASS: TestGetZoneRecords/TXT_Records (0.00s)
+=== RUN   TestListTsigKeys
+--- PASS: TestListTsigKeys (0.00s)
+    tsig_test.go:77: Returned Key List: &{0xc0001594a0 [0xc000155500 0xc000155540]}
+=== RUN   TestUpdateZoneKey
+--- PASS: TestUpdateZoneKey (0.00s)
+=== RUN   TestGetZoneKey
+--- PASS: TestGetZoneKey (0.00s)
+=== RUN   TestDeleteZoneKey
+--- PASS: TestDeleteZoneKey (0.00s)
+=== RUN   TestGetTsigKeyUsers
+--- PASS: TestGetTsigKeyUsers (0.00s)
+=== RUN   TestTsigKeyBulkUpdate
+--- PASS: TestTsigKeyBulkUpdate (0.00s)
+=== RUN   TestTsigKeyGetZones
+--- PASS: TestTsigKeyGetZones (0.00s)
+=== RUN   TestZone_JSON
+--- PASS: TestZone_JSON (0.00s)
+PASS
+ok  	github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2	0.019s

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/record.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/record.go
@@ -2,6 +2,7 @@ package dnsv2
 
 import (
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
+        edge "github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid"
 
 	"sync"
 )
@@ -90,6 +91,10 @@ func (record *RecordBody) Save(zone string) error {
 	if err != nil {
 		return err
 	}
+
+        edge.PrintHttpRequest(req, true)
+
+
 	res, err := client.Do(Config, req)
 
 	// Network error
@@ -100,6 +105,8 @@ func (record *RecordBody) Save(zone string) error {
 			err:              err,
 		}
 	}
+
+        edge.PrintHttpResponse(res, true)
 
 	// API error
 	if client.IsError(res) {
@@ -128,6 +135,9 @@ func (record *RecordBody) Update(zone string) error {
 	if err != nil {
 		return err
 	}
+
+        edge.PrintHttpRequest(req, true)
+
 	res, err := client.Do(Config, req)
 
 	// Network error
@@ -138,6 +148,8 @@ func (record *RecordBody) Update(zone string) error {
 			err:              err,
 		}
 	}
+
+        edge.PrintHttpResponse(res, true)
 
 	// API error
 	if client.IsError(res) {
@@ -165,6 +177,9 @@ func (record *RecordBody) Delete(zone string) error {
 	if err != nil {
 		return err
 	}
+
+        edge.PrintHttpRequest(req, true)
+
 	res, err := client.Do(Config, req)
 
 	// Network error
@@ -175,6 +190,8 @@ func (record *RecordBody) Delete(zone string) error {
 			err:              err,
 		}
 	}
+
+        edge.PrintHttpResponse(res, true)
 
 	// API error
 	if client.IsError(res) {

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/record.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/record.go
@@ -2,7 +2,7 @@ package dnsv2
 
 import (
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
-        edge "github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid"
+	edge "github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid"
 
 	"sync"
 )
@@ -92,8 +92,7 @@ func (record *RecordBody) Save(zone string) error {
 		return err
 	}
 
-        edge.PrintHttpRequest(req, true)
-
+	edge.PrintHttpRequest(req, true)
 
 	res, err := client.Do(Config, req)
 
@@ -106,7 +105,7 @@ func (record *RecordBody) Save(zone string) error {
 		}
 	}
 
-        edge.PrintHttpResponse(res, true)
+	edge.PrintHttpResponse(res, true)
 
 	// API error
 	if client.IsError(res) {
@@ -136,7 +135,7 @@ func (record *RecordBody) Update(zone string) error {
 		return err
 	}
 
-        edge.PrintHttpRequest(req, true)
+	edge.PrintHttpRequest(req, true)
 
 	res, err := client.Do(Config, req)
 
@@ -149,7 +148,7 @@ func (record *RecordBody) Update(zone string) error {
 		}
 	}
 
-        edge.PrintHttpResponse(res, true)
+	edge.PrintHttpResponse(res, true)
 
 	// API error
 	if client.IsError(res) {
@@ -178,7 +177,7 @@ func (record *RecordBody) Delete(zone string) error {
 		return err
 	}
 
-        edge.PrintHttpRequest(req, true)
+	edge.PrintHttpRequest(req, true)
 
 	res, err := client.Do(Config, req)
 
@@ -191,7 +190,7 @@ func (record *RecordBody) Delete(zone string) error {
 		}
 	}
 
-        edge.PrintHttpResponse(res, true)
+	edge.PrintHttpResponse(res, true)
 
 	// API error
 	if client.IsError(res) {

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/record.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/record.go
@@ -10,46 +10,48 @@ import (
 // https://developer.akamai.com/api/luna/config-dns/data.html
 
 type RecordBody struct {
-	Name                string   `json:"name,omitempty"`
-	RecordType          string   `json:"type,omitempty"`
-	TTL                 int      `json:"ttl,omitempty"`
-	Active              bool     `json:"active,omitempty"`
-	Target              []string `json:"rdata,omitempty"`
-	Subtype             int      `json:"subtype,omitempty"`                //AfsdbRecord
-	Flags               int      `json:"flags,omitempty"`                  //DnskeyRecord Nsec3paramRecord
-	Protocol            int      `json:"protocol,omitempty"`               //DnskeyRecord
-	Algorithm           int      `json:"algorithm,omitempty"`              //DnskeyRecord DsRecord Nsec3paramRecord RrsigRecord SshfpRecord
-	Key                 string   `json:"key,omitempty"`                    //DnskeyRecord
-	Keytag              int      `json:"keytag,omitempty"`                 //DsRecord RrsigRecord
-	DigestType          int      `json:"digest_type,omitempty"`            //DsRecord
-	Digest              string   `json:"digest,omitempty"`                 //DsRecord
-	Hardware            string   `json:"hardware,omitempty"`               //HinfoRecord
-	Software            string   `json:"software,omitempty"`               //HinfoRecord
-	Priority            int      `json:"priority,omitempty"`               //MxRecord SrvRecord
-	Order               uint16   `json:"order,omitempty"`                  //NaptrRecord
-	Preference          uint16   `json:"preference,omitempty"`             //NaptrRecord
-	FlagsNaptr          string   `json:"flags,omitempty"`                  //NaptrRecord
-	Service             string   `json:"service,omitempty"`                //NaptrRecord
-	Regexp              string   `json:"regexp,omitempty"`                 //NaptrRecord
-	Replacement         string   `json:"replacement,omitempty"`            //NaptrRecord
-	Iterations          int      `json:"iterations,omitempty"`             //Nsec3Record Nsec3paramRecord
-	Salt                string   `json:"salt,omitempty"`                   //Nsec3Record Nsec3paramRecord
-	NextHashedOwnerName string   `json:"next_hashed_owner_name,omitempty"` //Nsec3Record
-	TypeBitmaps         string   `json:"type_bitmaps,omitempty"`           //Nsec3Record
-	Mailbox             string   `json:"mailbox,omitempty"`                //RpRecord
-	Txt                 string   `json:"txt,omitempty"`                    //RpRecord
-	TypeCovered         string   `json:"type_covered,omitempty"`           //RrsigRecord
-	OriginalTTL         int      `json:"original_ttl,omitempty"`           //RrsigRecord
-	Expiration          string   `json:"expiration,omitempty"`             //RrsigRecord
-	Inception           string   `json:"inception,omitempty"`              //RrsigRecord
-	Signer              string   `json:"signer,omitempty"`                 //RrsigRecord
-	Signature           string   `json:"signature,omitempty"`              //RrsigRecord
-	Labels              int      `json:"labels,omitempty"`                 //RrsigRecord
-	Weight              uint16   `json:"weight,omitempty"`                 //SrvRecord
-	Port                uint16   `json:"port,omitempty"`                   //SrvRecord
-	FingerprintType     int      `json:"fingerprint_type,omitempty"`       //SshfpRecord
-	Fingerprint         string   `json:"fingerprint,omitempty"`            //SshfpRecord
-	PriorityIncrement   int      `json:"priority_increment,omitempty"`     //MX priority Increment
+	Name       string `json:"name,omitempty"`
+	RecordType string `json:"type,omitempty"`
+	TTL        int    `json:"ttl,omitempty"`
+	// Active field no longer used in v2
+	Active bool     `json:"active,omitempty"`
+	Target []string `json:"rdata,omitempty"`
+	// Remaining Fields are not used in the v2 API
+	Subtype             int    `json:"subtype,omitempty"`                //AfsdbRecord
+	Flags               int    `json:"flags,omitempty"`                  //DnskeyRecord Nsec3paramRecord
+	Protocol            int    `json:"protocol,omitempty"`               //DnskeyRecord
+	Algorithm           int    `json:"algorithm,omitempty"`              //DnskeyRecord DsRecord Nsec3paramRecord RrsigRecord SshfpRecord
+	Key                 string `json:"key,omitempty"`                    //DnskeyRecord
+	Keytag              int    `json:"keytag,omitempty"`                 //DsRecord RrsigRecord
+	DigestType          int    `json:"digest_type,omitempty"`            //DsRecord
+	Digest              string `json:"digest,omitempty"`                 //DsRecord
+	Hardware            string `json:"hardware,omitempty"`               //HinfoRecord
+	Software            string `json:"software,omitempty"`               //HinfoRecord
+	Priority            int    `json:"priority,omitempty"`               //MxRecord SrvRecord
+	Order               uint16 `json:"order,omitempty"`                  //NaptrRecord
+	Preference          uint16 `json:"preference,omitempty"`             //NaptrRecord
+	FlagsNaptr          string `json:"flags,omitempty"`                  //NaptrRecord
+	Service             string `json:"service,omitempty"`                //NaptrRecord
+	Regexp              string `json:"regexp,omitempty"`                 //NaptrRecord
+	Replacement         string `json:"replacement,omitempty"`            //NaptrRecord
+	Iterations          int    `json:"iterations,omitempty"`             //Nsec3Record Nsec3paramRecord
+	Salt                string `json:"salt,omitempty"`                   //Nsec3Record Nsec3paramRecord
+	NextHashedOwnerName string `json:"next_hashed_owner_name,omitempty"` //Nsec3Record
+	TypeBitmaps         string `json:"type_bitmaps,omitempty"`           //Nsec3Record
+	Mailbox             string `json:"mailbox,omitempty"`                //RpRecord
+	Txt                 string `json:"txt,omitempty"`                    //RpRecord
+	TypeCovered         string `json:"type_covered,omitempty"`           //RrsigRecord
+	OriginalTTL         int    `json:"original_ttl,omitempty"`           //RrsigRecord
+	Expiration          string `json:"expiration,omitempty"`             //RrsigRecord
+	Inception           string `json:"inception,omitempty"`              //RrsigRecord
+	Signer              string `json:"signer,omitempty"`                 //RrsigRecord
+	Signature           string `json:"signature,omitempty"`              //RrsigRecord
+	Labels              int    `json:"labels,omitempty"`                 //RrsigRecord
+	Weight              uint16 `json:"weight,omitempty"`                 //SrvRecord
+	Port                uint16 `json:"port,omitempty"`                   //SrvRecord
+	FingerprintType     int    `json:"fingerprint_type,omitempty"`       //SshfpRecord
+	Fingerprint         string `json:"fingerprint,omitempty"`            //SshfpRecord
+	PriorityIncrement   int    `json:"priority_increment,omitempty"`     //MX priority Increment
 }
 
 var (

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/record_lookup.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/record_lookup.go
@@ -221,7 +221,7 @@ func GetRecord(zone string, name string, record_type string) (*RecordBody, error
 	if client.IsError(res) && res.StatusCode != 404 {
 		return nil, client.NewAPIError(res)
 	} else if res.StatusCode == 404 {
-		return nil, &ZoneError{zoneName: zone}
+		return nil, &RecordError{fieldName: name}
 	} else {
 		err = client.BodyJSON(res, record)
 		if err != nil {
@@ -257,7 +257,7 @@ func GetRecordList(zone string, name string, record_type string) (*RecordSetResp
 	if client.IsError(res) && res.StatusCode != 404 {
 		return nil, client.NewAPIError(res)
 	} else if res.StatusCode == 404 {
-		return nil, &ZoneError{zoneName: name}
+		return nil, &RecordError{fieldName: name}
 	} else {
 		err = client.BodyJSON(res, records)
 		if err != nil {

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/record_lookup.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/record_lookup.go
@@ -303,19 +303,19 @@ func GetRdata(zone string, name string, record_type string) ([]string, error) {
 
 func ProcessRdata(rdata []string, rtype string) []string {
 
-        newrdata := make([]string, 0, len(rdata))
-        for _, i := range rdata {
-        	str := i
-                if rtype == "AAAA" {
-                        addr := net.ParseIP(str)
-                        result := FullIPv6(addr)
-                         str = result
-                } else if rtype == "LOC" {
-                         str = PadCoordinates(str)
-                }
-                rdata = append(rdata, str)
-        }
-        return newrdata
+	newrdata := make([]string, 0, len(rdata))
+	for _, i := range rdata {
+		str := i
+		if rtype == "AAAA" {
+			addr := net.ParseIP(str)
+			result := FullIPv6(addr)
+			str = result
+		} else if rtype == "LOC" {
+			str = PadCoordinates(str)
+		}
+		newrdata = append(newrdata, str)
+	}
+	return newrdata
 
 }
 
@@ -406,11 +406,11 @@ func ParseRData(rtype string, rdata []string) map[string]interface{} {
 			fieldMap["order"], _ = strconv.Atoi(parts[0])
 			fieldMap["preference"], _ = strconv.Atoi(parts[1])
 			//fieldMap["flagsnaptr"] = strings.Trim(parts[2], "\"")
-                        fieldMap["flagsnaptr"] = parts[2]
+			fieldMap["flagsnaptr"] = parts[2]
 			//fieldMap["service"] = strings.Trim(parts[3], "\"")
-                        fieldMap["service"] = parts[3]
+			fieldMap["service"] = parts[3]
 			//fieldMap["regexp"] = strings.Trim(parts[4], "\"")
-                        fieldMap["regexp"] = parts[4]
+			fieldMap["regexp"] = parts[4]
 			fieldMap["replacement"] = parts[5]
 			break
 		}
@@ -510,11 +510,11 @@ func ParseRData(rtype string, rdata []string) map[string]interface{} {
 		parts := strings.Split(rdata[0], " ")
 		fieldMap["answer_type"] = parts[0]
 		fieldMap["dns_name"] = parts[1]
-	
+
 	case "SPF":
 		for _, rcontent := range rdata {
 			//newrdata = append(newrdata, strings.Trim(rcontent, "\""))
-                        newrdata = append(newrdata, rcontent)
+			newrdata = append(newrdata, rcontent)
 		}
 		fieldMap["target"] = newrdata
 
@@ -526,24 +526,24 @@ func ParseRData(rtype string, rdata []string) map[string]interface{} {
 		}
 		fieldMap["target"] = newrdata
 
-        case "AAAA":
-                for _, i := range rdata {
-                        str := i
-                        addr := net.ParseIP(str)
-                        result := FullIPv6(addr)
-                        str = result
+	case "AAAA":
+		for _, i := range rdata {
+			str := i
+			addr := net.ParseIP(str)
+			result := FullIPv6(addr)
+			str = result
 			newrdata = append(newrdata, str)
 		}
-                fieldMap["target"] = newrdata
+		fieldMap["target"] = newrdata
 
-        case "LOC":
-                for _, i := range rdata {
-                        str := i
-                        str = PadCoordinates(str)
-                        newrdata = append(newrdata, str)
-                }
-                fieldMap["target"] = newrdata
-	
+	case "LOC":
+		for _, i := range rdata {
+			str := i
+			str = PadCoordinates(str)
+			newrdata = append(newrdata, str)
+		}
+		fieldMap["target"] = newrdata
+
 	default:
 		for _, rcontent := range rdata {
 			newrdata = append(newrdata, rcontent)

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/record_lookup.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/record_lookup.go
@@ -377,7 +377,6 @@ func ParseRData(rtype string, rdata []string) map[string]interface{} {
 
 	case "HINFO":
 		for _, rcontent := range rdata {
-			//rcontent = strings.ReplaceAll(rcontent, "\"", "\\\"")
 			parts := strings.Split(rcontent, " ")
 			fieldMap["hardware"] = parts[0]
 			fieldMap["software"] = parts[1]
@@ -397,7 +396,6 @@ func ParseRData(rtype string, rdata []string) map[string]interface{} {
 			parts := strings.Split(rcontent, " ")
 			newrdata = append(newrdata, parts[1])
 		}
-		sort.Strings(newrdata)
 		fieldMap["target"] = newrdata
 
 	case "NAPTR":
@@ -405,11 +403,8 @@ func ParseRData(rtype string, rdata []string) map[string]interface{} {
 			parts := strings.Split(rcontent, " ")
 			fieldMap["order"], _ = strconv.Atoi(parts[0])
 			fieldMap["preference"], _ = strconv.Atoi(parts[1])
-			//fieldMap["flagsnaptr"] = strings.Trim(parts[2], "\"")
 			fieldMap["flagsnaptr"] = parts[2]
-			//fieldMap["service"] = strings.Trim(parts[3], "\"")
 			fieldMap["service"] = parts[3]
-			//fieldMap["regexp"] = strings.Trim(parts[4], "\"")
 			fieldMap["regexp"] = parts[4]
 			fieldMap["replacement"] = parts[5]
 			break
@@ -513,15 +508,12 @@ func ParseRData(rtype string, rdata []string) map[string]interface{} {
 
 	case "SPF":
 		for _, rcontent := range rdata {
-			//newrdata = append(newrdata, strings.Trim(rcontent, "\""))
 			newrdata = append(newrdata, rcontent)
 		}
 		fieldMap["target"] = newrdata
 
 	case "TXT":
 		for _, rcontent := range rdata {
-			//rcontent = strings.Trim(rcontent, "\"")
-			//rcontent = strings.ReplaceAll(rcontent, "\"", "\\\"")
 			newrdata = append(newrdata, rcontent)
 		}
 		fieldMap["target"] = newrdata

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/record_test.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/record_test.go
@@ -1,10 +1,10 @@
 package dnsv2
 
 import (
-	"testing"
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/h2non/gock.v1"
+	"testing"
 )
 
 func TestRecord_ContainsHelper(t *testing.T) {
@@ -150,17 +150,17 @@ func TestRecord_AllRecords_WrongTypes(t *testing.T) {
 
 func TestGetRecordsetsNoArgs(t *testing.T) {
 
-        dnsTestZone := "testzone.com"
+	dnsTestZone := "testzone.com"
 
-        defer gock.Off()
+	defer gock.Off()
 
-        mock := gock.New(fmt.Sprintf("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-dns/v2/zones/%s/recordsets", dnsTestZone))
-        mock.
-                Get(fmt.Sprintf("/config-dns/v2/zones/%s/recordsets", dnsTestZone)).
-                HeaderPresent("Authorization").
-                Reply(200).
-                SetHeader("Content-Type", "application/json;charset=UTF-8").
-                BodyString(fmt.Sprintf(`{
+	mock := gock.New(fmt.Sprintf("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-dns/v2/zones/%s/recordsets", dnsTestZone))
+	mock.
+		Get(fmt.Sprintf("/config-dns/v2/zones/%s/recordsets", dnsTestZone)).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/json;charset=UTF-8").
+		BodyString(fmt.Sprintf(`{
     			"metadata": {
         			"lastPage": 1, 
         			"page": 1, 
@@ -187,27 +187,27 @@ func TestGetRecordsetsNoArgs(t *testing.T) {
         			}] 
 		}`))
 
-        Init(config)
+	Init(config)
 	recordsets, err := GetRecordsets(dnsTestZone)
-        assert.NoError(t, err)
-        assert.Equal(t, assert.IsType(t, &RecordSetResponse{}, recordsets), true)
-        assert.Equal(t, len(recordsets.Recordsets), 2)
+	assert.NoError(t, err)
+	assert.Equal(t, assert.IsType(t, &RecordSetResponse{}, recordsets), true)
+	assert.Equal(t, len(recordsets.Recordsets), 2)
 
 }
 
 func TestGetRecordsets(t *testing.T) {
 
-        dnsTestZone := "testzone.com"
+	dnsTestZone := "testzone.com"
 
-        defer gock.Off()
+	defer gock.Off()
 
-        mock := gock.New(fmt.Sprintf("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-dns/v2/zones/%s/recordsets", dnsTestZone))
-        mock.
-                Get(fmt.Sprintf("/config-dns/v2/zones/%s/recordsets", dnsTestZone)).
-                HeaderPresent("Authorization").
-                Reply(200).
-                SetHeader("Content-Type", "application/json;charset=UTF-8").
-                BodyString(fmt.Sprintf(`{
+	mock := gock.New(fmt.Sprintf("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-dns/v2/zones/%s/recordsets", dnsTestZone))
+	mock.
+		Get(fmt.Sprintf("/config-dns/v2/zones/%s/recordsets", dnsTestZone)).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/json;charset=UTF-8").
+		BodyString(fmt.Sprintf(`{
                         "metadata": {
                                 "lastPage": 1,
                                 "page": 1,
@@ -226,30 +226,30 @@ func TestGetRecordsets(t *testing.T) {
                                 }]
                 }`))
 
-        Init(config)
+	Init(config)
 	qargs := RecordsetQueryArgs{Search: "east.testzone.com", SortBy: "name"}
-        recordsets, err := GetRecordsets(dnsTestZone, qargs)
-        assert.NoError(t, err)
-        assert.Equal(t, assert.IsType(t, &RecordSetResponse{}, recordsets), true)
-        assert.Equal(t, len(recordsets.Recordsets), 1)
+	recordsets, err := GetRecordsets(dnsTestZone, qargs)
+	assert.NoError(t, err)
+	assert.Equal(t, assert.IsType(t, &RecordSetResponse{}, recordsets), true)
+	assert.Equal(t, len(recordsets.Recordsets), 1)
 
 }
 
 func TestGetRecord(t *testing.T) {
 
-        dnsTestZone := "testzone.com"
-        dnsTestRecordName := "east.testzone.com"
-        dnsTestRecordType := "CNAME"
+	dnsTestZone := "testzone.com"
+	dnsTestRecordName := "east.testzone.com"
+	dnsTestRecordType := "CNAME"
 
-        defer gock.Off()
+	defer gock.Off()
 
-        mock := gock.New(fmt.Sprintf("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-dns/v2/zones/%s/names/%s/types/%s", dnsTestZone, dnsTestRecordName, dnsTestRecordType))
-        mock.
-                Get(fmt.Sprintf("/config-dns/v2/zones/%s/names/%s/types/%s", dnsTestZone, dnsTestRecordName, dnsTestRecordType)).
-                HeaderPresent("Authorization").
-                Reply(200).
-                SetHeader("Content-Type", "application/json;charset=UTF-8").
-                BodyString(fmt.Sprintf(`{
+	mock := gock.New(fmt.Sprintf("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-dns/v2/zones/%s/names/%s/types/%s", dnsTestZone, dnsTestRecordName, dnsTestRecordType))
+	mock.
+		Get(fmt.Sprintf("/config-dns/v2/zones/%s/names/%s/types/%s", dnsTestZone, dnsTestRecordName, dnsTestRecordType)).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/json;charset=UTF-8").
+		BodyString(fmt.Sprintf(`{
                         "name": "east.testzone.com",
                         "rdata": [
                                  "east.testzone.com.edgesuite.net."
@@ -258,11 +258,10 @@ func TestGetRecord(t *testing.T) {
                         "type": "CNAME"
                 }`))
 
-        Init(config)
-        testrecord, err := GetRecord(dnsTestZone, dnsTestRecordName, "CNAME")
-        assert.NoError(t, err)
-        assert.Equal(t, assert.IsType(t, &RecordBody{}, testrecord), true)
-        assert.Equal(t, testrecord.Name, dnsTestRecordName)
+	Init(config)
+	testrecord, err := GetRecord(dnsTestZone, dnsTestRecordName, "CNAME")
+	assert.NoError(t, err)
+	assert.Equal(t, assert.IsType(t, &RecordBody{}, testrecord), true)
+	assert.Equal(t, testrecord.Name, dnsTestRecordName)
 
 }
-

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/record_test.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/record_test.go
@@ -2,8 +2,9 @@ package dnsv2
 
 import (
 	"testing"
-
+	"fmt"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/h2non/gock.v1"
 )
 
 func TestRecord_ContainsHelper(t *testing.T) {
@@ -146,3 +147,122 @@ func TestRecord_AllRecords_WrongTypes(t *testing.T) {
 	assert.Equal(t, e, &RecordError{fieldName: "name"})
 	*/
 }
+
+func TestGetRecordsetsNoArgs(t *testing.T) {
+
+        dnsTestZone := "testzone.com"
+
+        defer gock.Off()
+
+        mock := gock.New(fmt.Sprintf("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-dns/v2/zones/%s/recordsets", dnsTestZone))
+        mock.
+                Get(fmt.Sprintf("/config-dns/v2/zones/%s/recordsets", dnsTestZone)).
+                HeaderPresent("Authorization").
+                Reply(200).
+                SetHeader("Content-Type", "application/json;charset=UTF-8").
+                BodyString(fmt.Sprintf(`{
+    			"metadata": {
+        			"lastPage": 1, 
+        			"page": 1, 
+        			"pageSize": 25, 
+        			"showAll": false, 
+        			"totalElements": 2
+    			}, 
+    			"recordsets": [
+        			{
+            				"name": "east.testzone.com", 
+            				"rdata": [
+                				"east.testzone.com.edgesuite.net."
+            				], 
+            				"ttl": 600, 
+            				"type": "CNAME"
+        			}, 
+        			{
+            				"name": "easttest.testzone.com", 
+            				"rdata": [
+                				"easttest.testzone.com.edgesuite.net."
+            				], 
+            				"ttl": 600, 
+            				"type": "CNAME"
+        			}] 
+		}`))
+
+        Init(config)
+	recordsets, err := GetRecordsets(dnsTestZone)
+        assert.NoError(t, err)
+        assert.Equal(t, assert.IsType(t, &RecordSetResponse{}, recordsets), true)
+        assert.Equal(t, len(recordsets.Recordsets), 2)
+
+}
+
+func TestGetRecordsets(t *testing.T) {
+
+        dnsTestZone := "testzone.com"
+
+        defer gock.Off()
+
+        mock := gock.New(fmt.Sprintf("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-dns/v2/zones/%s/recordsets", dnsTestZone))
+        mock.
+                Get(fmt.Sprintf("/config-dns/v2/zones/%s/recordsets", dnsTestZone)).
+                HeaderPresent("Authorization").
+                Reply(200).
+                SetHeader("Content-Type", "application/json;charset=UTF-8").
+                BodyString(fmt.Sprintf(`{
+                        "metadata": {
+                                "lastPage": 1,
+                                "page": 1,
+                                "pageSize": 25,
+                                "showAll": false,
+                                "totalElements": 1
+                        },
+                        "recordsets": [
+                                {
+                                        "name": "east.testzone.com",
+                                        "rdata": [
+                                                "east.testzone.com.edgesuite.net."
+                                        ],
+                                        "ttl": 600,
+                                        "type": "CNAME"
+                                }]
+                }`))
+
+        Init(config)
+	qargs := RecordsetQueryArgs{Search: "east.testzone.com", SortBy: "name"}
+        recordsets, err := GetRecordsets(dnsTestZone, qargs)
+        assert.NoError(t, err)
+        assert.Equal(t, assert.IsType(t, &RecordSetResponse{}, recordsets), true)
+        assert.Equal(t, len(recordsets.Recordsets), 1)
+
+}
+
+func TestGetRecord(t *testing.T) {
+
+        dnsTestZone := "testzone.com"
+        dnsTestRecordName := "east.testzone.com"
+        dnsTestRecordType := "CNAME"
+
+        defer gock.Off()
+
+        mock := gock.New(fmt.Sprintf("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-dns/v2/zones/%s/names/%s/types/%s", dnsTestZone, dnsTestRecordName, dnsTestRecordType))
+        mock.
+                Get(fmt.Sprintf("/config-dns/v2/zones/%s/names/%s/types/%s", dnsTestZone, dnsTestRecordName, dnsTestRecordType)).
+                HeaderPresent("Authorization").
+                Reply(200).
+                SetHeader("Content-Type", "application/json;charset=UTF-8").
+                BodyString(fmt.Sprintf(`{
+                        "name": "east.testzone.com",
+                        "rdata": [
+                                 "east.testzone.com.edgesuite.net."
+                        ],
+                        "ttl": 600,
+                        "type": "CNAME"
+                }`))
+
+        Init(config)
+        testrecord, err := GetRecord(dnsTestZone, dnsTestRecordName, "CNAME")
+        assert.NoError(t, err)
+        assert.Equal(t, assert.IsType(t, &RecordBody{}, testrecord), true)
+        assert.Equal(t, testrecord.Name, dnsTestRecordName)
+
+}
+

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/service.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/service.go
@@ -13,4 +13,6 @@ var (
 // Init sets the DNSv2 edgegrid Config
 func Init(config edgegrid.Config) {
 	Config = config
+	edgegrid.SetupLogging()
+
 }

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/service_test.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/service_test.go
@@ -5,8 +5,8 @@ import (
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid"
 	"testing"
 
-	"gopkg.in/h2non/gock.v1"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/h2non/gock.v1"
 )
 
 var (

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/tsig.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/tsig.go
@@ -1,0 +1,398 @@
+package dnsv2
+
+import (
+	"fmt"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
+	edge "github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid"
+	"reflect"
+	"strings"
+	"sync"
+)
+
+var (
+	tsigWriteLock sync.Mutex
+)
+
+// TODO: Add examples?
+
+type TSIGQueryString struct {
+	ContractIds []string `json:"contractIds,omitempty"`
+	Search      string   `json:"search,omitempty"`
+	SortBy      []string `json:"sortBy,omitempty"`
+	Gid         int64    `json:"gid,omitempty"`
+}
+
+type TSIGKey struct {
+	Name      string `json:"name"`
+	Algorithm string `json:"algorithm,omitempty"`
+	Secret    string `json:"secret,omitempty"`
+}
+
+type TSIGKeyResponse struct {
+	TSIGKey
+	ZoneCount int64 `json:"zoneCount,omitempty"`
+}
+
+type TSIGKeyBulkPost struct {
+	Key   *TSIGKey `json:"key"`
+	Zones []string `json:"zones"`
+}
+
+type TSIGZoneAliases struct {
+	Aliases []string `json:"aliases"`
+}
+
+type TSIGReportMeta struct {
+	TotalElements int64    `json:"totalElements"`
+	Search        string   `json:"search,omitempty"`
+	Contracts     []string `json:"contracts,omitempty"`
+	Gid           int64    `json:"gid,omitempty"`
+	SortBy        []string `json:"sortBy,omitempty"`
+}
+
+type TSIGReportResponse struct {
+	Metadata *TSIGReportMeta    `json:"metadata"`
+	Keys     []*TSIGKeyResponse `json:"keys,omitempty"`
+}
+
+// Return bare bones tsig key struct
+func NewTSIGKey(name string) *TSIGKey {
+	key := &TSIGKey{Name: name}
+	return key
+}
+
+// Return empty query string struct. No elements required.
+func NewTSIGQueryString() *TSIGQueryString {
+	tsigquerystring := &TSIGQueryString{}
+	return tsigquerystring
+}
+
+func constructTsigQueryString(tsigquerystring *TSIGQueryString) string {
+
+	queryString := ""
+	qsElems := reflect.ValueOf(tsigquerystring).Elem()
+	for i := 0; i < qsElems.NumField(); i++ {
+		varName := qsElems.Type().Field(i).Name
+		varValue := qsElems.Field(i).Interface()
+		keyVal := fmt.Sprint(varValue)
+		switch varName {
+		case "ContractIds":
+			contractList := ""
+			for j, id := range varValue.([]string) {
+				contractList += id
+				if j < len(varValue.([]string))-1 {
+					contractList += "%2C"
+				}
+			}
+			if len(varValue.([]string)) > 0 {
+				queryString += "contractIds=" + contractList
+			}
+		case "SortBy":
+			sortByList := ""
+			for j, sb := range varValue.([]string) {
+				sortByList += sb
+				if j < len(varValue.([]string))-1 {
+					sortByList += "%2C"
+				}
+			}
+			if len(varValue.([]string)) > 0 {
+				queryString += "sortBy=" + sortByList
+			}
+		case "Search":
+			if keyVal != "" {
+				queryString += "search=" + keyVal
+			}
+		case "Gid":
+			if varValue.(int64) != 0 {
+				queryString += "gid=" + keyVal
+			}
+		}
+		if i < qsElems.NumField()-1 {
+			queryString += "&"
+		}
+	}
+	queryString = strings.TrimRight(queryString, "&")
+	if len(queryString) > 0 {
+		return "?" + queryString
+	} else {
+		return ""
+	}
+}
+
+// List TSIG Keys
+func ListTsigKeys(tsigquerystring *TSIGQueryString) (*TSIGReportResponse, error) {
+
+	tsigList := &TSIGReportResponse{}
+	req, err := client.NewRequest(
+		Config,
+		"GET",
+		fmt.Sprintf("/config-dns/v2/keys%s", constructTsigQueryString(tsigquerystring)),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	edge.PrintHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+
+	// Network error
+	if err != nil {
+		return nil, &TsigError{
+			keyName:          "TsigKeyList",
+			httpErrorMessage: err.Error(),
+			err:              err,
+		}
+	}
+
+	edge.PrintHttpResponse(res, true)
+
+	// API error
+	if client.IsError(res) {
+		err := client.NewAPIError(res)
+		return nil, &TsigError{keyName: "TsigKeyList", apiErrorMessage: err.Detail, err: err}
+	}
+
+	err = client.BodyJSON(res, tsigList)
+	if err != nil {
+		return nil, err
+	}
+
+	return tsigList, nil
+
+}
+
+// GetZones retrieves DNS Zones using tsig key
+func (tsigKey *TSIGKey) GetZones() (*ZoneNameListResponse, error) {
+
+	zonesList := &ZoneNameListResponse{}
+	req, err := client.NewJSONRequest(
+		Config,
+		"POST",
+		"/config-dns/v2/keys/used-by",
+		tsigKey,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	edge.PrintHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	edge.PrintHttpResponse(res, true)
+
+	if client.IsError(res) && res.StatusCode != 404 {
+		return nil, client.NewAPIError(res)
+	} else if res.StatusCode == 404 {
+		return nil, &TsigError{keyName: tsigKey.Name}
+	} else {
+		err = client.BodyJSON(res, zonesList)
+		if err != nil {
+			return nil, err
+		}
+
+		return zonesList, nil
+	}
+}
+
+// GetZoneKeyAliases retrieves a DNS Zone's aliases
+//func GetZoneKeyAliases(zone string) (*TSIGZoneAliases, error) {
+//
+// There is a discrepency between the technical doc and API operation. API currently returns a zone name list.
+// TODO: Reconcile
+//
+func GetZoneKeyAliases(zone string) (*ZoneNameListResponse, error) {
+
+	zonesList := &ZoneNameListResponse{}
+	//zoneAliases :=&TSIGZoneAliases{}
+	req, err := client.NewRequest(
+		Config,
+		"GET",
+		fmt.Sprintf("/config-dns/v2/zones/%s/key/used-by", zone),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	edge.PrintHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	edge.PrintHttpResponse(res, true)
+
+	if client.IsError(res) && res.StatusCode != 404 {
+		return nil, client.NewAPIError(res)
+	} else if res.StatusCode == 404 {
+		return nil, &ZoneError{zoneName: zone}
+	} else {
+		//err = client.BodyJSON(res, zoneAliases)
+		err = client.BodyJSON(res, zonesList)
+		if err != nil {
+			return nil, err
+		}
+
+		//return zoneAliases, nil
+		return zonesList, nil
+	}
+}
+
+// Bulk Zones tsig key update
+func (tsigBulk *TSIGKeyBulkPost) BulkUpdate() error {
+
+	req, err := client.NewJSONRequest(
+		Config,
+		"POST",
+		"/config-dns/v2/keys/bulk-update",
+		tsigBulk,
+	)
+	if err != nil {
+		return err
+	}
+
+	edge.PrintHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+
+	edge.PrintHttpResponse(res, true)
+
+	// Network error
+	if err != nil {
+		return &TsigError{
+			keyName:          tsigBulk.Key.Name,
+			httpErrorMessage: err.Error(),
+			err:              err,
+		}
+	}
+
+	// API error
+	if client.IsError(res) {
+		err := client.NewAPIError(res)
+		return &TsigError{keyName: tsigBulk.Key.Name, apiErrorMessage: err.Detail, err: err}
+	}
+
+	return nil
+}
+
+// GetZoneKey retrieves a DNS Zone's key
+func GetZoneKey(zone string) (*TSIGKeyResponse, error) {
+
+	zonekey := &TSIGKeyResponse{}
+	req, err := client.NewRequest(
+		Config,
+		"GET",
+		fmt.Sprintf("/config-dns/v2/zones/%s/key", zone),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	edge.PrintHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	edge.PrintHttpResponse(res, true)
+
+	if client.IsError(res) && res.StatusCode != 404 {
+		return nil, client.NewAPIError(res)
+	} else if res.StatusCode == 404 {
+		return nil, &ZoneError{zoneName: zone}
+	} else {
+		err = client.BodyJSON(res, zonekey)
+		if err != nil {
+			return nil, err
+		}
+
+		return zonekey, nil
+	}
+}
+
+// Delete tsig key for zone
+func DeleteZoneKey(zone string) error {
+
+	req, err := client.NewRequest(
+		Config,
+		"DELETE",
+		fmt.Sprintf("/config-dns/v2/zones/%s/key", zone),
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+
+	edge.PrintHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+
+	// Network error
+	if err != nil {
+		return &ZoneError{
+			zoneName:         zone,
+			httpErrorMessage: err.Error(),
+			err:              err,
+		}
+	}
+
+	edge.PrintHttpResponse(res, true)
+
+	// API error
+	if client.IsError(res) {
+		err := client.NewAPIError(res)
+		return &ZoneError{zoneName: zone, apiErrorMessage: err.Detail, err: err}
+	}
+
+	return nil
+
+}
+
+// Update tsig key for zone
+func (tsigKey *TSIGKey) Update(zone string) error {
+
+	req, err := client.NewJSONRequest(
+		Config,
+		"PUT",
+		fmt.Sprintf("/config-dns/v2/zones/%s/key", zone),
+		tsigKey,
+	)
+	if err != nil {
+		return err
+	}
+
+	edge.PrintHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+	// Network error
+	if err != nil {
+		return &TsigError{
+			keyName:          tsigKey.Name,
+			httpErrorMessage: err.Error(),
+			err:              err,
+		}
+	}
+
+	edge.PrintHttpResponse(res, true)
+
+	// API error
+	if client.IsError(res) {
+		err := client.NewAPIError(res)
+		return &TsigError{keyName: tsigKey.Name, apiErrorMessage: err.Detail, err: err}
+	}
+
+	return nil
+
+}

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/tsig_test.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/tsig_test.go
@@ -1,0 +1,211 @@
+package dnsv2
+
+import (
+	"testing"
+	//edge "github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid"
+	"fmt"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/jsonhooks-v1"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/h2non/gock.v1"
+)
+
+var (
+	dnsTestZone = "dns.test.zone.com"
+	tsigBody    = []byte(fmt.Sprintf(`{
+    			"name": "%s",
+    			"algorithm": "hmac-md5",
+    			"secret": "p/jzrJpXOLf4mPUtx/z+Sw=="
+		}`, dnsTestZone))
+
+	tsigKeyResponse = fmt.Sprintf(`{
+                        "name": "%s",
+                        "algorithm": "hmac-md5",
+                        "secret": "p/jzrJpXOLf4mPUtx/z+Sw==",
+			"zonesCount": 1
+                }`, dnsTestZone)
+)
+
+func createTestTsigKey() *TSIGKey {
+
+	key := &TSIGKey{}
+	jsonhooks.Unmarshal(tsigBody, key)
+
+	return key
+
+}
+
+func TestListTsigKeys(t *testing.T) {
+
+	/*
+			// for live testing
+		        config, err := edge.Init("","")
+		        if err != nil {
+		                t.Fatalf("TestListTsigKeys failed initializing: %s", err.Error())
+		        }
+	*/
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-dns/v2/keys")
+	mock.
+		Get("/config-dns/v2/keys").
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/json;charset=UTF-8").
+		BodyString(fmt.Sprint(`{
+			"metadata": {
+				"totalElements":2
+			},
+			"keys": [{
+				"name":"mbnewtsig",
+				"algorithm":"HMAC-MD5.SIG-ALG.REG.INT",
+				"secret":"abc78w==",
+				"zonesCount":2
+			},{
+				"name":"fred",
+				"algorithm":"hmac-sha256",
+				"secret":"IxSErTXxsCN8JO1jsAqW4We0rwbdu5R2jwFFmXoS//Y=",
+				"zonesCount":1
+			}]
+		}`))
+
+	Init(config)
+	tsigQueryString := &TSIGQueryString{}
+	tsigReport, err := ListTsigKeys(tsigQueryString)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(len(tsigReport.Keys)), tsigReport.Metadata.TotalElements)
+
+}
+
+func TestUpdateZoneKey(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New(fmt.Sprintf("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-dns/v2/zones/%s/key", dnsTestZone))
+	mock.
+		Put(fmt.Sprintf("/config-dns/v2/zones/%s/key", dnsTestZone)).
+		HeaderPresent("Authorization").
+		Reply(204).
+		SetHeader("Content-Type", "application/json;charset=UTF-8")
+
+	Init(config)
+	testKey := createTestTsigKey()
+	err := testKey.Update(dnsTestZone)
+	assert.NoError(t, err)
+	/*
+			// live testing ...
+			zoneResp, err := GetZone("xxxxxxxxxxxxx.com")
+		        assert.NoError(t, err)
+			assert.Equal(t, testKey.Name, zoneResp.TsigKey.Name)
+	*/
+
+}
+
+func TestGetZoneKey(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New(fmt.Sprintf("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-dns/v2/zones/%s/key", dnsTestZone))
+	mock.
+		Get(fmt.Sprintf("/config-dns/v2/zones/%s/key", dnsTestZone)).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/json;charset=UTF-8").
+		BodyString(tsigKeyResponse)
+	Init(config)
+	keyResp, err := GetZoneKey(dnsTestZone)
+	if err == nil {
+		fmt.Sprintf("Key resp: %v", keyResp)
+	} else {
+		fmt.Sprintf(err.Error())
+	}
+	assert.NoError(t, err)
+	assert.Equal(t, keyResp.Name, createTestTsigKey().Name)
+
+}
+
+func TestDeleteZoneKey(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New(fmt.Sprintf("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-dns/v2/zones/%s/key", dnsTestZone))
+	mock.
+		Delete(fmt.Sprintf("/config-dns/v2/zones/%s/key", dnsTestZone)).
+		HeaderPresent("Authorization").
+		Reply(204).
+		SetHeader("Content-Type", "application/json;charset=UTF-8")
+
+	Init(config)
+	err := DeleteZoneKey(dnsTestZone)
+	assert.NoError(t, err)
+
+}
+
+func TestGetTsigKeyUsers(t *testing.T) {
+
+	//
+	// NOTE: Currently a discrepency between docs and API operation!!!
+	// TODO: Reconcile and correct
+	//
+
+	defer gock.Off()
+
+	mock := gock.New(fmt.Sprintf("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-dns/v2/zones/%s/key/used-by", dnsTestZone))
+	mock.
+		Get(fmt.Sprintf("/config-dns/v2/zones/%s/key/used-by", dnsTestZone)).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/json;charset=UTF-8").
+		BodyString(fmt.Sprintf(`{
+                    "zones":["%s"]
+		}`, dnsTestZone))
+
+	Init(config)
+	zoneKeyAliases, err := GetZoneKeyAliases(dnsTestZone)
+	assert.NoError(t, err)
+	// CORRECT
+	assert.Equal(t, assert.IsType(t, &ZoneNameListResponse{}, zoneKeyAliases), true)
+	//assert.Equal(t, assert.IsType(t, &TSIGZoneAliases{}, zoneKeyAliases), true)
+
+}
+
+func TestTsigKeyBulkUpdate(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-dns/v2/keys/bulk-update")
+	mock.
+		Post("/config-dns/v2/keys/bulk-update").
+		HeaderPresent("Authorization").
+		Reply(204).
+		SetHeader("Content-Type", "application/json;charset=UTF-8")
+
+	Init(config)
+	testKey := createTestTsigKey()
+	bulkUpdate := &TSIGKeyBulkPost{Key: testKey, Zones: []string{dnsTestZone}}
+	err := bulkUpdate.BulkUpdate()
+	assert.NoError(t, err)
+
+}
+
+func TestTsigKeyGetZones(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-dns/v2/keys/used-by")
+	mock.
+		Post("/config-dns/v2/keys/used-by").
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/json;charset=UTF-8").
+		BodyString(fmt.Sprintf(`{
+                        "zones":["%s"]
+                }`, dnsTestZone))
+
+	Init(config)
+	testKey := createTestTsigKey()
+	zoneList, err := testKey.GetZones()
+	assert.NoError(t, err)
+	assert.Equal(t, assert.IsType(t, &ZoneNameListResponse{}, zoneList), true)
+
+}

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/zone.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/zone.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"reflect"
 	"sync"
+	"strings"
 )
 
 var (
@@ -482,6 +483,7 @@ func (zone *ZoneCreate) Delete(zonequerystring ZoneQueryString) error {
 
 func filterZoneCreate(zone *ZoneCreate) map[string]interface{} {
 
+	zoneType := strings.ToUpper(zone.Type)
 	filteredZone := make(map[string]interface{})
 	zoneElems := reflect.ValueOf(zone).Elem()
 	for i := 0; i < zoneElems.NumField(); i++ {
@@ -490,23 +492,23 @@ func filterZoneCreate(zone *ZoneCreate) map[string]interface{} {
 		varValue := zoneElems.Field(i).Interface()
 		switch varName {
 		case "Target":
-			if zone.Type == "ALIAS" {
+			if zoneType == "ALIAS" {
 				filteredZone[varLower] = varValue
 			}
 		case "TsigKey":
-			if zone.Type == "SECONDARY" {
+			if zoneType == "SECONDARY" {
 				filteredZone[varLower] = varValue
 			}
 		case "Masters":
-			if zone.Type == "SECONDARY" {
+			if zoneType == "SECONDARY" {
 				filteredZone[varLower] = varValue
 			}
 		case "SignAndServe":
-			if zone.Type != "ALIAS" {
+			if zoneType != "ALIAS" {
 				filteredZone[varLower] = varValue
 			}
 		case "SignAndServeAlgorithm":
-			if zone.Type != "ALIAS" {
+			if zoneType != "ALIAS" {
 				filteredZone[varLower] = varValue
 			}
 		default:

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/zone.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/zone.go
@@ -2,6 +2,7 @@ package dnsv2
 
 import (
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
+	edge "github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid"
 	"io/ioutil"
 	"log"
 	"sync"
@@ -42,25 +43,35 @@ type ZoneQueryString struct {
 }
 
 type ZoneCreate struct {
-	Zone         string   `json:"zone,omitempty"`
-	Type         string   `json:"type,omitempty"`
-	Masters      []string `json:"masters,omitempty"`
-	Comment      string   `json:"comment,omitempty"`
-	SignAndServe bool     `json:"signAndServe"`
+	Zone                  string   `json:"zone"`
+	Type                  string   `json:"type"`
+	Masters               []string `json:"masters,omitempty"`
+	Comment               string   `json:"comment,omitempty"`
+	SignAndServe          bool     `json:"signAndServe,omitempty"`
+	SignAndServeAlgorithm string   `json:"signAndServeAlgorithm,omitempty"`
+	TsigKey               *TSIGKey `json:"tsigKey,omitempty"`
+	Target                string   `json:"target,omitempty"`
+	EndCustomerId         string   `json:"endCustomerId,omitempty"`
+	ContractId            string   `json:"contractid,omitempty"`
 }
 
 type ZoneResponse struct {
-	Zone               string   `json:"zone,omitempty"`
-	Type               string   `json:"type,omitempty"`
-	Masters            []string `json:"masters,omitempty"`
-	Comment            string   `json:"comment,omitempty"`
-	ActivationState    string   `json:"activationstate,omitempty"`
-	ContractId         string   `json:"contractid,omitempty"`
-	LastActivationDate string   `json:"lastactivationdate,omitempty"`
-	LastModifiedBy     string   `json:"lastmodifiedby,omitempty"`
-	LastModifiedDate   string   `json:"lastmodifieddate,omitempty"`
-	SignAndServe       bool     `json:"signandserve"`
-	VersionId          string   `json:"versionid,omitempty"`
+	Zone                  string   `json:"zone,omitempty"`
+	Type                  string   `json:"type,omitempty"`
+	Masters               []string `json:"masters,omitempty"`
+	Comment               string   `json:"comment,omitempty"`
+	SignAndServe          bool     `json:"signAndServe"`
+	SignAndServeAlgorithm string   `json:"signAndServeAlgorithm,omitempty"`
+	TsigKey               *TSIGKey `json:"tsigKey,omitempty"`
+	Target                string   `json:"target,omitempty"`
+	EndCustomerId         string   `json:"endCustomerId,omitempty"`
+	ContractId            string   `json:"contractid,omitempty"`
+	AliasCount            int64    `json:"aliasCount,omitempty"`
+	ActivationState       string   `json:"activationstate,omitempty"`
+	LastActivationDate    string   `json:"lastactivationdate,omitempty"`
+	LastModifiedBy        string   `json:"lastmodifiedby,omitempty"`
+	LastModifiedDate      string   `json:"lastmodifieddate,omitempty"`
+	VersionId             string   `json:"versionid,omitempty"`
 }
 
 type ChangeListResponse struct {
@@ -71,9 +82,22 @@ type ChangeListResponse struct {
 	Stale            bool   `json:"stale,omitempty"`
 }
 
-// NewZone creates a new Zone
+type ZoneNameListResponse struct {
+	Zones []string `json:"zones"`
+}
+
+// NewZone creates a new Zone. Supports subset of fields
 func NewZone(params ZoneCreate) *ZoneCreate {
-	zone := &ZoneCreate{Zone: params.Zone, Type: params.Type, Masters: params.Masters, Comment: params.Comment, SignAndServe: params.SignAndServe}
+	zone := &ZoneCreate{Zone: params.Zone,
+		Type:                  params.Type,
+		Masters:               params.Masters,
+		TsigKey:               params.TsigKey,
+		Target:                params.Target,
+		EndCustomerId:         params.EndCustomerId,
+		ContractId:            params.ContractId,
+		Comment:               params.Comment,
+		SignAndServe:          params.SignAndServe,
+		SignAndServeAlgorithm: params.SignAndServeAlgorithm}
 	return zone
 }
 
@@ -106,10 +130,14 @@ func GetZone(zonename string) (*ZoneResponse, error) {
 		return nil, err
 	}
 
+	edge.PrintHttpRequest(req, true)
+
 	res, err := client.Do(Config, req)
 	if err != nil {
 		return nil, err
 	}
+
+	edge.PrintHttpResponse(res, true)
 
 	if client.IsError(res) && res.StatusCode != 404 {
 		return nil, client.NewAPIError(res)
@@ -138,10 +166,14 @@ func GetChangeList(zone string) (*ChangeListResponse, error) {
 		return nil, err
 	}
 
+	edge.PrintHttpRequest(req, true)
+
 	res, err := client.Do(Config, req)
 	if err != nil {
 		return nil, err
 	}
+
+	edge.PrintHttpResponse(res, true)
 
 	if client.IsError(res) && res.StatusCode != 404 {
 		return nil, client.NewAPIError(res)
@@ -170,11 +202,16 @@ func GetMasterZoneFile(zone string) (string, error) {
 		return "", err
 	}
 	req.Header.Add("Accept", "text/dns")
+
+	edge.PrintHttpRequest(req, true)
+
 	res, err := client.Do(Config, req)
 	if err != nil {
 		log.Printf("[DEBUG] [Akamai LIB] ZM %v %v", res, err)
 		return "", err
 	}
+
+	edge.PrintHttpResponse(res, true)
 
 	if client.IsError(res) && res.StatusCode != 404 {
 		return "", client.NewAPIError(res)
@@ -191,7 +228,7 @@ func GetMasterZoneFile(zone string) (string, error) {
 	}
 }
 
-// Save updates the Zone
+// Create a Zone
 func (zone *ZoneCreate) Save(zonequerystring ZoneQueryString) error {
 	// This lock will restrict the concurrency of API calls
 	// to 1 save request at a time. This is needed for the Soa.Serial value which
@@ -211,6 +248,8 @@ func (zone *ZoneCreate) Save(zonequerystring ZoneQueryString) error {
 		return err
 	}
 
+	edge.PrintHttpRequest(req, true)
+
 	res, err := client.Do(Config, req)
 
 	// Network error
@@ -222,6 +261,8 @@ func (zone *ZoneCreate) Save(zonequerystring ZoneQueryString) error {
 		}
 	}
 
+	edge.PrintHttpResponse(res, true)
+
 	// API error
 	if client.IsError(res) {
 		err := client.NewAPIError(res)
@@ -231,7 +272,7 @@ func (zone *ZoneCreate) Save(zonequerystring ZoneQueryString) error {
 	return nil
 }
 
-// Save changelist for the Zone to create default NS SOA records
+// Create changelist for the Zone. Side effect is to create default NS SOA records
 func (zone *ZoneCreate) SaveChangelist() error {
 	// This lock will restrict the concurrency of API calls
 	// to 1 save request at a time. This is needed for the Soa.Serial value which
@@ -249,6 +290,8 @@ func (zone *ZoneCreate) SaveChangelist() error {
 		return err
 	}
 
+	edge.PrintHttpRequest(req, true)
+
 	res, err := client.Do(Config, req)
 
 	// Network error
@@ -259,6 +302,8 @@ func (zone *ZoneCreate) SaveChangelist() error {
 			err:              err,
 		}
 	}
+
+	edge.PrintHttpResponse(res, true)
 
 	// API error
 	if client.IsError(res) {
@@ -287,6 +332,8 @@ func (zone *ZoneCreate) SubmitChangelist() error {
 		return err
 	}
 
+	edge.PrintHttpRequest(req, true)
+
 	res, err := client.Do(Config, req)
 
 	// Network error
@@ -297,6 +344,8 @@ func (zone *ZoneCreate) SubmitChangelist() error {
 			err:              err,
 		}
 	}
+
+	edge.PrintHttpResponse(res, true)
 
 	// API error
 	if client.IsError(res) {
@@ -325,6 +374,8 @@ func (zone *ZoneCreate) Update(zonequerystring ZoneQueryString) error {
 		return err
 	}
 
+	edge.PrintHttpRequest(req, true)
+
 	res, err := client.Do(Config, req)
 
 	// Network error
@@ -335,6 +386,8 @@ func (zone *ZoneCreate) Update(zonequerystring ZoneQueryString) error {
 			err:              err,
 		}
 	}
+
+	edge.PrintHttpResponse(res, true)
 
 	// API error
 	if client.IsError(res) {
@@ -359,6 +412,8 @@ func (zone *ZoneCreate) Delete(zonequerystring ZoneQueryString) error {
 		return err
 	}
 
+	edge.PrintHttpRequest(req, true)
+
 	res, err := client.Do(Config, req)
 
 	// Network error
@@ -369,6 +424,8 @@ func (zone *ZoneCreate) Delete(zonequerystring ZoneQueryString) error {
 			err:              err,
 		}
 	}
+
+	edge.PrintHttpResponse(res, true)
 
 	// API error
 	if client.IsError(res) {

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/zone_test.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/zone_test.go
@@ -2,9 +2,10 @@ package dnsv2
 
 import (
 	"testing"
-
+	"fmt"
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/jsonhooks-v1"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/h2non/gock.v1"
 )
 
 func TestZone_JSON(t *testing.T) {
@@ -24,3 +25,54 @@ func TestZone_JSON(t *testing.T) {
 	assert.Equal(t, zone.Comment, "This is a test zone")
 	assert.Equal(t, zone.SignAndServe, false)
 }
+
+func TestGetZoneNames(t *testing.T) {
+
+	dnsTestZone := "testzone.com"
+
+	defer gock.Off()
+
+	mock := gock.New(fmt.Sprintf("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-dns/v2/zones/%s/names", dnsTestZone))
+	mock.
+		Get(fmt.Sprintf("/config-dns/v2/zones/%s/names", dnsTestZone)).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/json;charset=UTF-8").
+		BodyString(fmt.Sprintf(`{
+                        "names":["test1.testzone.com","test2.testzone.com"]
+                }`))
+
+	Init(config)
+	nameList, err := GetZoneNames(dnsTestZone)
+	assert.NoError(t, err)
+	assert.Equal(t, assert.IsType(t, &ZoneNamesResponse{}, nameList), true)
+	assert.Equal(t, len(nameList.Names), 2)
+
+}
+
+func TestGetZoneNameTypes(t *testing.T) {
+
+        dnsTestZone := "testzone.com"
+	dnsTestRecordName := "test.testzone.com"
+
+        defer gock.Off()
+
+        mock := gock.New(fmt.Sprintf("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-dns/v2/zones/%s/names/%s/types", dnsTestZone, dnsTestRecordName))
+        mock.
+                Get(fmt.Sprintf("/config-dns/v2/zones/%s/names/%s/types", dnsTestZone, dnsTestRecordName)).
+                HeaderPresent("Authorization").
+                Reply(200).
+                SetHeader("Content-Type", "application/json;charset=UTF-8").
+                BodyString(fmt.Sprintf(`{
+                        "types":["CNAME", "AKAMAICDN"]
+                }`))
+
+        Init(config)
+        typeList, err := GetZoneNameTypes(dnsTestRecordName, dnsTestZone)
+        assert.NoError(t, err)
+        assert.Equal(t, assert.IsType(t, &ZoneNameTypesResponse{}, typeList), true)
+        assert.Equal(t, len(typeList.Types), 2)
+
+}
+
+

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/zone_test.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/zone_test.go
@@ -15,7 +15,7 @@ func TestZone_JSON(t *testing.T) {
     "signAndServe": false
 }`)
 
-	zonecreate := ZoneCreate{"example.com", "PRIMARY", []string{""}, "This is a test zone", false}
+	zonecreate := ZoneCreate{Zone: "example.com", Type: "PRIMARY", Masters: []string{""}, Comment: "This is a test zone", SignAndServe: false}
 	zone := NewZone(zonecreate)
 	err := jsonhooks.Unmarshal(responseBody, zone)
 	assert.NoError(t, err)

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/zone_test.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v2/zone_test.go
@@ -1,11 +1,11 @@
 package dnsv2
 
 import (
-	"testing"
 	"fmt"
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/jsonhooks-v1"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/h2non/gock.v1"
+	"testing"
 )
 
 func TestZone_JSON(t *testing.T) {
@@ -52,27 +52,25 @@ func TestGetZoneNames(t *testing.T) {
 
 func TestGetZoneNameTypes(t *testing.T) {
 
-        dnsTestZone := "testzone.com"
+	dnsTestZone := "testzone.com"
 	dnsTestRecordName := "test.testzone.com"
 
-        defer gock.Off()
+	defer gock.Off()
 
-        mock := gock.New(fmt.Sprintf("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-dns/v2/zones/%s/names/%s/types", dnsTestZone, dnsTestRecordName))
-        mock.
-                Get(fmt.Sprintf("/config-dns/v2/zones/%s/names/%s/types", dnsTestZone, dnsTestRecordName)).
-                HeaderPresent("Authorization").
-                Reply(200).
-                SetHeader("Content-Type", "application/json;charset=UTF-8").
-                BodyString(fmt.Sprintf(`{
+	mock := gock.New(fmt.Sprintf("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-dns/v2/zones/%s/names/%s/types", dnsTestZone, dnsTestRecordName))
+	mock.
+		Get(fmt.Sprintf("/config-dns/v2/zones/%s/names/%s/types", dnsTestZone, dnsTestRecordName)).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/json;charset=UTF-8").
+		BodyString(fmt.Sprintf(`{
                         "types":["CNAME", "AKAMAICDN"]
                 }`))
 
-        Init(config)
-        typeList, err := GetZoneNameTypes(dnsTestRecordName, dnsTestZone)
-        assert.NoError(t, err)
-        assert.Equal(t, assert.IsType(t, &ZoneNameTypesResponse{}, typeList), true)
-        assert.Equal(t, len(typeList.Types), 2)
+	Init(config)
+	typeList, err := GetZoneNameTypes(dnsTestRecordName, dnsTestZone)
+	assert.NoError(t, err)
+	assert.Equal(t, assert.IsType(t, &ZoneNameTypesResponse{}, typeList), true)
+	assert.Equal(t, len(typeList.Types), 2)
 
 }
-
-

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configgtm-v1_3/service.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configgtm-v1_3/service.go
@@ -1,52 +1,34 @@
 package configgtm
 
 import (
-	"net/http"
-	"net/http/httputil"
-
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid"
-	"github.com/sirupsen/logrus"
+	"net/http"
 )
 
 var (
 	// Config contains the Akamai OPEN Edgegrid API credentials
 	// for automatic signing of requests
 	Config edgegrid.Config
-	// Create a new instance of the logger.
-	GtmLog *logrus.Logger
 )
 
 // Init sets the GTM edgegrid Config
 func Init(config edgegrid.Config) {
 
 	Config = config
-	GtmLog = logrus.New()
-	edgegrid.SetupLogging(GtmLog)
-	if edgegrid.LogFile != nil {
-		defer edgegrid.LogFile.Close()
-	}
+	edgegrid.SetupLogging()
+
 }
 
 // Utility func to print http req
 func printHttpRequest(req *http.Request, body bool) {
-	if req == nil {
-		return
-	}
 
-	b, err := httputil.DumpRequestOut(req, body)
-	if err == nil {
-		edgegrid.LogMultiline(GtmLog.Traceln, string(b))
-	}
+	edgegrid.PrintHttpRequest(req, body)
+
 }
 
 // Utility func to print http response
 func printHttpResponse(res *http.Response, body bool) {
-	if res == nil {
-		return
-	}
 
-	b, err := httputil.DumpResponse(res, body)
-	if err == nil {
-		edgegrid.LogMultiline(GtmLog.Traceln, string(b))
-	}
+	edgegrid.PrintHttpResponse(res, body)
+
 }

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configgtm-v1_4/asmap.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configgtm-v1_4/asmap.go
@@ -14,7 +14,7 @@ import (
 // AsAssignment represents a GTM asmap assignment structure
 type AsAssignment struct {
 	DatacenterBase
-	AsNumbers []int64 `json:"asNumbers,omitempty"`
+	AsNumbers []int64 `json:"asNumbers"`
 }
 
 // AsMap  represents a GTM AsMap

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configgtm-v1_4/cidrmap.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configgtm-v1_4/cidrmap.go
@@ -14,7 +14,7 @@ import (
 //CidrAssignment represents a GTM cidr assignment element
 type CidrAssignment struct {
 	DatacenterBase
-	Blocks []string `json:"blocks,omitempty"`
+	Blocks []string `json:"blocks"`
 }
 
 // CidrMap  represents a GTM cidrMap element

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configgtm-v1_4/datacenter_test.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configgtm-v1_4/datacenter_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/jsonhooks-v1"
-
+	//edge "github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/h2non/gock.v1"
 
@@ -314,5 +314,68 @@ func TestDeleteDatacenter(t *testing.T) {
 	testDC := instantiateDatacenter()
 	_, err := testDC.Delete(gtmTestDomain)
 	assert.NoError(t, err)
+
+}
+
+func TestCreateMapsDefaultDatacenter(t *testing.T) {
+
+	defer gock.Off()
+
+	mock1 := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/datacenters/5400")
+	mock1.
+		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/datacenters/5400").
+		HeaderPresent("Authorization").
+		Reply(404).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8")
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/datacenters/default-datacenter-for-maps")
+	mock.
+		Post("/config-gtm/v1/domains/"+gtmTestDomain+"/datacenters/default-datacenter-for-maps").
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                        "resource" : {
+                                "datacenterId" : 5400,
+                                "nickname" : "Default Datacenter",
+                                "scorePenalty" : 0,
+                                "city" : null,
+                                "stateOrProvince" : null,
+                                "country" : null,
+                                "latitude" : null,
+                                "longitude" : null,
+                                "cloneOf" : null,
+                                "virtual" : true,
+                                "defaultLoadObject" : null,
+                                "continent" : null,
+                                "servermonitorPool" : null,
+                                "servermonitorLivenessCount" : null,
+                                "servermonitorLoadCount" : null,
+                                "pingInterval" : null,
+                                "pingPacketSize" : null,
+                                "cloudServerTargeting" : false,
+                                "cloudServerHostHeaderOverride" : false,
+                                "links" : [ {
+                                        "rel" : "self",
+                                        "href" : "https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/datacenters/5400"
+                                } ]
+                        },
+                        "status" : {
+                                "message" : "Change Pending",
+                                "changeId" : "4c7e6466-84e1-4895-bdf5-e3608d708d69",
+                                "propagationStatus" : "PENDING",
+                                "propagationStatusDate" : "2019-05-30T17:47:02.831+00:00",
+                                "passingValidation" : true,
+                                "links" : [ {
+                                        "rel" : "self",
+                                        "href" : "https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/status/current"
+                                } ]
+                        }
+                }`)
+
+	Init(config)
+	defDC, err := CreateMapsDefaultDatacenter(gtmTestDomain)
+	assert.NoError(t, err)
+	assert.Equal(t, defDC.DatacenterId, 5400)
 
 }

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configgtm-v1_4/domain.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configgtm-v1_4/domain.go
@@ -265,7 +265,7 @@ func (domain *Domain) Create(queryArgs map[string]string) (*DomainResponse, erro
 
 // Update is a method applied to a domain object resulting in an update.
 func (domain *Domain) Update(queryArgs map[string]string) (*ResponseStatus, error) {
-	
+
 	// Any validation to do?
 	req, err := client.NewJSONRequest(
 		Config,

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configgtm-v1_4/geomap.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configgtm-v1_4/geomap.go
@@ -14,7 +14,7 @@ import (
 // GeoAssigment represents a GTM geo assignment element
 type GeoAssignment struct {
 	DatacenterBase
-	Countries []string `json:"countries,omitempty"`
+	Countries []string `json:"countries"`
 }
 
 // GeoMap  represents a GTM GeoMap

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configgtm-v1_4/property.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configgtm-v1_4/property.go
@@ -50,7 +50,7 @@ type LivenessTest struct {
 	TestObjectUsername            string        `json:"testObjectUsername,omitempty"`
 	TestTimeout                   float32       `json:"testTimeout,omitempty"`
 	TimeoutPenalty                float64       `json:"timeoutPenalty,omitempty"`
-	AnswersRequired                bool         `json:"answersRequired"`
+	AnswersRequired               bool          `json:"answersRequired"`
 	ResourceType                  string        `json:"resourceType,omitempty"`
 	RecursionRequested            bool          `json:"recursionRequested"`
 }

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configgtm-v1_4/service.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/configgtm-v1_4/service.go
@@ -2,50 +2,33 @@ package configgtm
 
 import (
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid"
-	"github.com/sirupsen/logrus"
 	"net/http"
-	"net/http/httputil"
 )
 
 var (
 	// Config contains the Akamai OPEN Edgegrid API credentials
 	// for automatic signing of requests
 	Config edgegrid.Config
-	// Create a new instance of the logger.
-	GtmLog *logrus.Logger
 )
 
 // Init sets the GTM edgegrid Config
 func Init(config edgegrid.Config) {
 
 	Config = config
-	GtmLog = logrus.New()
-	edgegrid.SetupLogging(GtmLog)
-	if edgegrid.LogFile != nil {
-		defer edgegrid.LogFile.Close()
-	}
+	edgegrid.SetupLogging()
+
 }
 
 // Utility func to print http req
 func printHttpRequest(req *http.Request, body bool) {
 
-	if req == nil {
-		return
-	}
-	b, err := httputil.DumpRequestOut(req, body)
-	if err == nil {
-		edgegrid.LogMultiline(GtmLog.Traceln, string(b))
-	}
+	edgegrid.PrintHttpRequest(req, body)
+
 }
 
 // Utility func to print http response
 func printHttpResponse(res *http.Response, body bool) {
 
-	if res == nil {
-		return
-	}
-	b, err := httputil.DumpResponse(res, body)
-	if err == nil {
-		edgegrid.LogMultiline(GtmLog.Traceln, string(b))
-	}
+	edgegrid.PrintHttpResponse(res, body)
+
 }

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid.go
@@ -18,10 +18,10 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/go-ini/ini"
 	"github.com/google/uuid"
 	"github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
+	"gopkg.in/ini.v1"
 )
 
 const defaultSection = "DEFAULT"

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid/config.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid/config.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-ini/ini"
 	"github.com/mitchellh/go-homedir"
+	"gopkg.in/ini.v1"
 )
 
 // Config struct provides all the necessary fields to

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid/profilecache.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid/profilecache.go
@@ -1,0 +1,23 @@
+package edgegrid
+
+import (
+	"time"
+
+	"github.com/patrickmn/go-cache"
+	gocache "github.com/patrickmn/go-cache"
+)
+
+// Config struct provides all the necessary fields to
+// create authorization header, debug is optional
+type (
+	profileCache gocache.Cache
+)
+
+// Init initializes cache
+//
+
+// See: InitCache()
+func InitCache() (gocache.Cache, error) {
+	cache := cache.New(5*time.Minute, 10*time.Minute)
+	return *cache, nil
+}

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid/signer.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid/signer.go
@@ -179,9 +179,6 @@ func createContentHash(config Config, req *http.Request) string {
 // but including the ; right before the signature field).
 func signingData(config Config, req *http.Request, authHeader string) string {
 
-        log.Debugf("Path: [%s]", req.URL.Path)
-        log.Debugf("Escaped Path: [%s]", req.URL.EscapedPath())
-
 	dataSign := []string{
 		req.Method,
 		req.URL.Scheme,

--- a/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/reportsgtm-v1/service.go
+++ b/vendor/github.com/akamai/AkamaiOPEN-edgegrid-golang/reportsgtm-v1/service.go
@@ -2,44 +2,33 @@ package reportsgtm
 
 import (
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid"
-	"github.com/sirupsen/logrus"
 	"net/http"
-	"net/http/httputil"
 )
 
 var (
 	// Config contains the Akamai OPEN Edgegrid API credentials
 	// for automatic signing of requests
 	Config edgegrid.Config
-	// Create a new instance of the logger.
-	GtmLog *logrus.Logger
 )
 
 // Init sets the GTM edgegrid Config
 func Init(config edgegrid.Config) {
 
 	Config = config
-	GtmLog = logrus.New()
-	edgegrid.SetupLogging(GtmLog)
-	if edgegrid.LogFile != nil {
-		defer edgegrid.LogFile.Close()
-	}
+	edgegrid.SetupLogging()
+
 }
 
 // Utility func to print http req
 func printHttpRequest(req *http.Request, body bool) {
 
-	b, err := httputil.DumpRequestOut(req, body)
-	if err == nil {
-		edgegrid.LogMultiline(GtmLog.Traceln, string(b))
-	}
+	edgegrid.PrintHttpRequest(req, body)
+
 }
 
 // Utility func to print http response
 func printHttpResponse(res *http.Response, body bool) {
 
-	b, err := httputil.DumpResponse(res, body)
-	if err == nil {
-		edgegrid.LogMultiline(GtmLog.Traceln, string(b))
-	}
+	edgegrid.PrintHttpResponse(res, body)
+
 }

--- a/vendor/github.com/hashicorp/terraform/helper/customdiff/compose.go
+++ b/vendor/github.com/hashicorp/terraform/helper/customdiff/compose.go
@@ -1,0 +1,72 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// All returns a CustomizeDiffFunc that runs all of the given
+// CustomizeDiffFuncs and returns all of the errors produced.
+//
+// If one function produces an error, functions after it are still run.
+// If this is not desirable, use function Sequence instead.
+//
+// If multiple functions returns errors, the result is a multierror.
+//
+// For example:
+//
+//     &schema.Resource{
+//         // ...
+//         CustomizeDiff: customdiff.All(
+//             customdiff.ValidateChange("size", func (old, new, meta interface{}) error {
+//                 // If we are increasing "size" then the new value must be
+//                 // a multiple of the old value.
+//                 if new.(int) <= old.(int) {
+//                     return nil
+//                 }
+//                 if (new.(int) % old.(int)) != 0 {
+//                     return fmt.Errorf("new size value must be an integer multiple of old value %d", old.(int))
+//                 }
+//                 return nil
+//             }),
+//             customdiff.ForceNewIfChange("size", func (old, new, meta interface{}) bool {
+//                 // "size" can only increase in-place, so we must create a new resource
+//                 // if it is decreased.
+//                 return new.(int) < old.(int)
+//             }),
+//             customdiff.ComputedIf("version_id", func (d *schema.ResourceDiff, meta interface{}) bool {
+//                 // Any change to "content" causes a new "version_id" to be allocated.
+//                 return d.HasChange("content")
+//             }),
+//         ),
+//     }
+//
+func All(funcs ...schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		var err error
+		for _, f := range funcs {
+			thisErr := f(d, meta)
+			if thisErr != nil {
+				err = multierror.Append(err, thisErr)
+			}
+		}
+		return err
+	}
+}
+
+// Sequence returns a CustomizeDiffFunc that runs all of the given
+// CustomizeDiffFuncs in sequence, stopping at the first one that returns
+// an error and returning that error.
+//
+// If all functions succeed, the combined function also succeeds.
+func Sequence(funcs ...schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		for _, f := range funcs {
+			err := f(d, meta)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform/helper/customdiff/compose_test.go
+++ b/vendor/github.com/hashicorp/terraform/helper/customdiff/compose_test.go
@@ -1,0 +1,110 @@
+package customdiff
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func TestAll(t *testing.T) {
+	var aCalled, bCalled, cCalled bool
+
+	provider := testProvider(
+		map[string]*schema.Schema{},
+		All(
+			func(d *schema.ResourceDiff, meta interface{}) error {
+				aCalled = true
+				return errors.New("A bad")
+			},
+			func(d *schema.ResourceDiff, meta interface{}) error {
+				bCalled = true
+				return nil
+			},
+			func(d *schema.ResourceDiff, meta interface{}) error {
+				cCalled = true
+				return errors.New("C bad")
+			},
+		),
+	)
+
+	_, err := testDiff(
+		provider,
+		map[string]string{
+			"foo": "bar",
+		},
+		map[string]string{
+			"foo": "baz",
+		},
+	)
+
+	if err == nil {
+		t.Fatal("Diff succeeded; want error")
+	}
+	if s, sub := err.Error(), "* A bad"; !strings.Contains(s, sub) {
+		t.Errorf("Missing substring %q in error message %q", sub, s)
+	}
+	if s, sub := err.Error(), "* C bad"; !strings.Contains(s, sub) {
+		t.Errorf("Missing substring %q in error message %q", sub, s)
+	}
+
+	if !aCalled {
+		t.Error("customize callback A was not called")
+	}
+	if !bCalled {
+		t.Error("customize callback B was not called")
+	}
+	if !cCalled {
+		t.Error("customize callback C was not called")
+	}
+}
+
+func TestSequence(t *testing.T) {
+	var aCalled, bCalled, cCalled bool
+
+	provider := testProvider(
+		map[string]*schema.Schema{},
+		Sequence(
+			func(d *schema.ResourceDiff, meta interface{}) error {
+				aCalled = true
+				return nil
+			},
+			func(d *schema.ResourceDiff, meta interface{}) error {
+				bCalled = true
+				return errors.New("B bad")
+			},
+			func(d *schema.ResourceDiff, meta interface{}) error {
+				cCalled = true
+				return errors.New("C bad")
+			},
+		),
+	)
+
+	_, err := testDiff(
+		provider,
+		map[string]string{
+			"foo": "bar",
+		},
+		map[string]string{
+			"foo": "baz",
+		},
+	)
+
+	if err == nil {
+		t.Fatal("Diff succeeded; want error")
+	}
+	if got, want := err.Error(), "B bad"; got != want {
+		t.Errorf("Wrong error message %q; want %q", got, want)
+	}
+
+	if !aCalled {
+		t.Error("customize callback A was not called")
+	}
+	if !bCalled {
+		t.Error("customize callback B was not called")
+	}
+	if cCalled {
+		t.Error("customize callback C was called (should not have been)")
+	}
+}

--- a/vendor/github.com/hashicorp/terraform/helper/customdiff/computed.go
+++ b/vendor/github.com/hashicorp/terraform/helper/customdiff/computed.go
@@ -1,0 +1,16 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// ComputedIf returns a CustomizeDiffFunc that sets the given key's new value
+// as computed if the given condition function returns true.
+func ComputedIf(key string, f ResourceConditionFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		if f(d, meta) {
+			d.SetNewComputed(key)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform/helper/customdiff/computed_test.go
+++ b/vendor/github.com/hashicorp/terraform/helper/customdiff/computed_test.go
@@ -1,0 +1,126 @@
+package customdiff
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func TestComputedIf(t *testing.T) {
+	t.Run("true", func(t *testing.T) {
+		var condCalls int
+		var gotOld, gotNew string
+
+		provider := testProvider(
+			map[string]*schema.Schema{
+				"foo": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"comp": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+			ComputedIf("comp", func(d *schema.ResourceDiff, meta interface{}) bool {
+				// When we set "ForceNew", our CustomizeDiff function is actually
+				// called a second time to construct the "create" portion of
+				// the replace diff. On the second call, the old value is masked
+				// as "" to suggest that the object is being created rather than
+				// updated.
+
+				condCalls++
+				old, new := d.GetChange("foo")
+				gotOld = old.(string)
+				gotNew = new.(string)
+
+				return true
+			}),
+		)
+
+		diff, err := testDiff(
+			provider,
+			map[string]string{
+				"foo":  "bar",
+				"comp": "old",
+			},
+			map[string]string{
+				"foo": "baz",
+			},
+		)
+
+		if err != nil {
+			t.Fatalf("Diff failed with error: %s", err)
+		}
+
+		if condCalls != 1 {
+			t.Fatalf("Wrong number of conditional callback calls %d; want %d", condCalls, 1)
+		} else {
+			if got, want := gotOld, "bar"; got != want {
+				t.Errorf("wrong old value %q on first call; want %q", got, want)
+			}
+			if got, want := gotNew, "baz"; got != want {
+				t.Errorf("wrong new value %q on first call; want %q", got, want)
+			}
+		}
+
+		if !diff.Attributes["comp"].NewComputed {
+			t.Error("Attribute 'comp' is not marked as NewComputed")
+		}
+	})
+	t.Run("false", func(t *testing.T) {
+		var condCalls int
+		var gotOld, gotNew string
+
+		provider := testProvider(
+			map[string]*schema.Schema{
+				"foo": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"comp": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+			ComputedIf("comp", func(d *schema.ResourceDiff, meta interface{}) bool {
+				condCalls++
+				old, new := d.GetChange("foo")
+				gotOld = old.(string)
+				gotNew = new.(string)
+
+				return false
+			}),
+		)
+
+		diff, err := testDiff(
+			provider,
+			map[string]string{
+				"foo":  "bar",
+				"comp": "old",
+			},
+			map[string]string{
+				"foo": "baz",
+			},
+		)
+
+		if err != nil {
+			t.Fatalf("Diff failed with error: %s", err)
+		}
+
+		if condCalls != 1 {
+			t.Fatalf("Wrong number of conditional callback calls %d; want %d", condCalls, 1)
+		} else {
+			if got, want := gotOld, "bar"; got != want {
+				t.Errorf("wrong old value %q on first call; want %q", got, want)
+			}
+			if got, want := gotNew, "baz"; got != want {
+				t.Errorf("wrong new value %q on first call; want %q", got, want)
+			}
+		}
+
+		if diff.Attributes["comp"] != nil && diff.Attributes["comp"].NewComputed {
+			t.Error("Attribute 'foo' is marked as NewComputed, but should not be")
+		}
+	})
+}

--- a/vendor/github.com/hashicorp/terraform/helper/customdiff/condition.go
+++ b/vendor/github.com/hashicorp/terraform/helper/customdiff/condition.go
@@ -1,0 +1,60 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// ResourceConditionFunc is a function type that makes a boolean decision based
+// on an entire resource diff.
+type ResourceConditionFunc func(d *schema.ResourceDiff, meta interface{}) bool
+
+// ValueChangeConditionFunc is a function type that makes a boolean decision
+// by comparing two values.
+type ValueChangeConditionFunc func(old, new, meta interface{}) bool
+
+// ValueConditionFunc is a function type that makes a boolean decision based
+// on a given value.
+type ValueConditionFunc func(value, meta interface{}) bool
+
+// If returns a CustomizeDiffFunc that calls the given condition
+// function and then calls the given CustomizeDiffFunc only if the condition
+// function returns true.
+//
+// This can be used to include conditional customizations when composing
+// customizations using All and Sequence, but should generally be used only in
+// simple scenarios. Prefer directly writing a CustomizeDiffFunc containing
+// a conditional branch if the given CustomizeDiffFunc is already a
+// locally-defined function, since this avoids obscuring the control flow.
+func If(cond ResourceConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		if cond(d, meta) {
+			return f(d, meta)
+		}
+		return nil
+	}
+}
+
+// IfValueChange returns a CustomizeDiffFunc that calls the given condition
+// function with the old and new values of the given key and then calls the
+// given CustomizeDiffFunc only if the condition function returns true.
+func IfValueChange(key string, cond ValueChangeConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		if cond(old, new, meta) {
+			return f(d, meta)
+		}
+		return nil
+	}
+}
+
+// IfValue returns a CustomizeDiffFunc that calls the given condition
+// function with the new values of the given key and then calls the
+// given CustomizeDiffFunc only if the condition function returns true.
+func IfValue(key string, cond ValueConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		if cond(d.Get(key), meta) {
+			return f(d, meta)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform/helper/customdiff/condition_test.go
+++ b/vendor/github.com/hashicorp/terraform/helper/customdiff/condition_test.go
@@ -1,0 +1,348 @@
+package customdiff
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func TestIf(t *testing.T) {
+	t.Run("true", func(t *testing.T) {
+		var condCalled, customCalled bool
+		var gotOld, gotNew string
+
+		provider := testProvider(
+			map[string]*schema.Schema{
+				"foo": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+			If(
+				func(d *schema.ResourceDiff, meta interface{}) bool {
+					condCalled = true
+					old, new := d.GetChange("foo")
+					gotOld = old.(string)
+					gotNew = new.(string)
+					return true
+				},
+				func(d *schema.ResourceDiff, meta interface{}) error {
+					customCalled = true
+					return errors.New("bad")
+				},
+			),
+		)
+
+		_, err := testDiff(
+			provider,
+			map[string]string{
+				"foo": "bar",
+			},
+			map[string]string{
+				"foo": "baz",
+			},
+		)
+
+		if err == nil {
+			t.Fatal("Diff succeeded; want error")
+		}
+		if got, want := err.Error(), "bad"; got != want {
+			t.Fatalf("wrong error message %q; want %q", got, want)
+		}
+
+		if !condCalled {
+			t.Error("condition callback was not called")
+		} else {
+			if got, want := gotOld, "bar"; got != want {
+				t.Errorf("wrong old value %q; want %q", got, want)
+			}
+			if got, want := gotNew, "baz"; got != want {
+				t.Errorf("wrong new value %q; want %q", got, want)
+			}
+		}
+
+		if !customCalled {
+			t.Error("customize callback was not called")
+		}
+	})
+	t.Run("false", func(t *testing.T) {
+		var condCalled, customCalled bool
+		var gotOld, gotNew string
+
+		provider := testProvider(
+			map[string]*schema.Schema{
+				"foo": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+			If(
+				func(d *schema.ResourceDiff, meta interface{}) bool {
+					condCalled = true
+					old, new := d.GetChange("foo")
+					gotOld = old.(string)
+					gotNew = new.(string)
+					return false
+				},
+				func(d *schema.ResourceDiff, meta interface{}) error {
+					customCalled = true
+					return errors.New("bad")
+				},
+			),
+		)
+
+		_, err := testDiff(
+			provider,
+			map[string]string{
+				"foo": "bar",
+			},
+			map[string]string{
+				"foo": "baz",
+			},
+		)
+
+		if err != nil {
+			t.Fatalf("Diff error %q; want success", err.Error())
+		}
+
+		if !condCalled {
+			t.Error("condition callback was not called")
+		} else {
+			if got, want := gotOld, "bar"; got != want {
+				t.Errorf("wrong old value %q; want %q", got, want)
+			}
+			if got, want := gotNew, "baz"; got != want {
+				t.Errorf("wrong new value %q; want %q", got, want)
+			}
+		}
+
+		if customCalled {
+			t.Error("customize callback was called (should not have been)")
+		}
+	})
+}
+
+func TestIfValueChange(t *testing.T) {
+	t.Run("true", func(t *testing.T) {
+		var condCalled, customCalled bool
+		var gotOld, gotNew string
+
+		provider := testProvider(
+			map[string]*schema.Schema{
+				"foo": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+			IfValueChange(
+				"foo",
+				func(old, new, meta interface{}) bool {
+					condCalled = true
+					gotOld = old.(string)
+					gotNew = new.(string)
+					return true
+				},
+				func(d *schema.ResourceDiff, meta interface{}) error {
+					customCalled = true
+					return errors.New("bad")
+				},
+			),
+		)
+
+		_, err := testDiff(
+			provider,
+			map[string]string{
+				"foo": "bar",
+			},
+			map[string]string{
+				"foo": "baz",
+			},
+		)
+
+		if err == nil {
+			t.Fatal("Diff succeeded; want error")
+		}
+		if got, want := err.Error(), "bad"; got != want {
+			t.Fatalf("wrong error message %q; want %q", got, want)
+		}
+
+		if !condCalled {
+			t.Error("condition callback was not called")
+		} else {
+			if got, want := gotOld, "bar"; got != want {
+				t.Errorf("wrong old value %q; want %q", got, want)
+			}
+			if got, want := gotNew, "baz"; got != want {
+				t.Errorf("wrong new value %q; want %q", got, want)
+			}
+		}
+
+		if !customCalled {
+			t.Error("customize callback was not called")
+		}
+	})
+	t.Run("false", func(t *testing.T) {
+		var condCalled, customCalled bool
+		var gotOld, gotNew string
+
+		provider := testProvider(
+			map[string]*schema.Schema{
+				"foo": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+			IfValueChange(
+				"foo",
+				func(old, new, meta interface{}) bool {
+					condCalled = true
+					gotOld = old.(string)
+					gotNew = new.(string)
+					return false
+				},
+				func(d *schema.ResourceDiff, meta interface{}) error {
+					customCalled = true
+					return errors.New("bad")
+				},
+			),
+		)
+
+		_, err := testDiff(
+			provider,
+			map[string]string{
+				"foo": "bar",
+			},
+			map[string]string{
+				"foo": "baz",
+			},
+		)
+
+		if err != nil {
+			t.Fatalf("Diff error %q; want success", err.Error())
+		}
+
+		if !condCalled {
+			t.Error("condition callback was not called")
+		} else {
+			if got, want := gotOld, "bar"; got != want {
+				t.Errorf("wrong old value %q; want %q", got, want)
+			}
+			if got, want := gotNew, "baz"; got != want {
+				t.Errorf("wrong new value %q; want %q", got, want)
+			}
+		}
+
+		if customCalled {
+			t.Error("customize callback was called (should not have been)")
+		}
+	})
+}
+
+func TestIfValue(t *testing.T) {
+	t.Run("true", func(t *testing.T) {
+		var condCalled, customCalled bool
+		var gotValue string
+
+		provider := testProvider(
+			map[string]*schema.Schema{
+				"foo": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+			IfValue(
+				"foo",
+				func(value, meta interface{}) bool {
+					condCalled = true
+					gotValue = value.(string)
+					return true
+				},
+				func(d *schema.ResourceDiff, meta interface{}) error {
+					customCalled = true
+					return errors.New("bad")
+				},
+			),
+		)
+
+		_, err := testDiff(
+			provider,
+			map[string]string{
+				"foo": "bar",
+			},
+			map[string]string{
+				"foo": "baz",
+			},
+		)
+
+		if err == nil {
+			t.Fatal("Diff succeeded; want error")
+		}
+		if got, want := err.Error(), "bad"; got != want {
+			t.Fatalf("wrong error message %q; want %q", got, want)
+		}
+
+		if !condCalled {
+			t.Error("condition callback was not called")
+		} else {
+			if got, want := gotValue, "baz"; got != want {
+				t.Errorf("wrong value %q; want %q", got, want)
+			}
+		}
+
+		if !customCalled {
+			t.Error("customize callback was not called")
+		}
+	})
+	t.Run("false", func(t *testing.T) {
+		var condCalled, customCalled bool
+		var gotValue string
+
+		provider := testProvider(
+			map[string]*schema.Schema{
+				"foo": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+			IfValue(
+				"foo",
+				func(value, meta interface{}) bool {
+					condCalled = true
+					gotValue = value.(string)
+					return false
+				},
+				func(d *schema.ResourceDiff, meta interface{}) error {
+					customCalled = true
+					return errors.New("bad")
+				},
+			),
+		)
+
+		_, err := testDiff(
+			provider,
+			map[string]string{
+				"foo": "bar",
+			},
+			map[string]string{
+				"foo": "baz",
+			},
+		)
+
+		if err != nil {
+			t.Fatalf("Diff error %q; want success", err.Error())
+		}
+
+		if !condCalled {
+			t.Error("condition callback was not called")
+		} else {
+			if got, want := gotValue, "baz"; got != want {
+				t.Errorf("wrong value %q; want %q", got, want)
+			}
+		}
+
+		if customCalled {
+			t.Error("customize callback was called (should not have been)")
+		}
+	})
+}

--- a/vendor/github.com/hashicorp/terraform/helper/customdiff/doc.go
+++ b/vendor/github.com/hashicorp/terraform/helper/customdiff/doc.go
@@ -1,0 +1,11 @@
+// Package customdiff provides a set of reusable and composable functions
+// to enable more "declarative" use of the CustomizeDiff mechanism available
+// for resources in package helper/schema.
+//
+// The intent of these helpers is to make the intent of a set of diff
+// customizations easier to see, rather than lost in a sea of Go function
+// boilerplate. They should _not_ be used in situations where they _obscure_
+// intent, e.g. by over-using the composition functions where a single
+// function containing normal Go control flow statements would be more
+// straightforward.
+package customdiff

--- a/vendor/github.com/hashicorp/terraform/helper/customdiff/force_new.go
+++ b/vendor/github.com/hashicorp/terraform/helper/customdiff/force_new.go
@@ -1,0 +1,40 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// ForceNewIf returns a CustomizeDiffFunc that flags the given key as
+// requiring a new resource if the given condition function returns true.
+//
+// The return value of the condition function is ignored if the old and new
+// values of the field compare equal, since no attribute diff is generated in
+// that case.
+func ForceNewIf(key string, f ResourceConditionFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		if f(d, meta) {
+			d.ForceNew(key)
+		}
+		return nil
+	}
+}
+
+// ForceNewIfChange returns a CustomizeDiffFunc that flags the given key as
+// requiring a new resource if the given condition function returns true.
+//
+// The return value of the condition function is ignored if the old and new
+// values compare equal, since no attribute diff is generated in that case.
+//
+// This function is similar to ForceNewIf but provides the condition function
+// only the old and new values of the given key, which leads to more compact
+// and explicit code in the common case where the decision can be made with
+// only the specific field value.
+func ForceNewIfChange(key string, f ValueChangeConditionFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		if f(old, new, meta) {
+			d.ForceNew(key)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform/helper/customdiff/force_new_test.go
+++ b/vendor/github.com/hashicorp/terraform/helper/customdiff/force_new_test.go
@@ -1,0 +1,249 @@
+package customdiff
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func TestForceNewIf(t *testing.T) {
+	t.Run("true", func(t *testing.T) {
+		var condCalls int
+		var gotOld1, gotNew1, gotOld2, gotNew2 string
+
+		provider := testProvider(
+			map[string]*schema.Schema{
+				"foo": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+			ForceNewIf("foo", func(d *schema.ResourceDiff, meta interface{}) bool {
+				// When we set "ForceNew", our CustomizeDiff function is actually
+				// called a second time to construct the "create" portion of
+				// the replace diff. On the second call, the old value is masked
+				// as "" to suggest that the object is being created rather than
+				// updated.
+
+				condCalls++
+				old, new := d.GetChange("foo")
+
+				switch condCalls {
+				case 1:
+					gotOld1 = old.(string)
+					gotNew1 = new.(string)
+				case 2:
+					gotOld2 = old.(string)
+					gotNew2 = new.(string)
+				}
+
+				return true
+			}),
+		)
+
+		diff, err := testDiff(
+			provider,
+			map[string]string{
+				"foo": "bar",
+			},
+			map[string]string{
+				"foo": "baz",
+			},
+		)
+
+		if err != nil {
+			t.Fatalf("Diff failed with error: %s", err)
+		}
+
+		if condCalls != 2 {
+			t.Fatalf("Wrong number of conditional callback calls %d; want %d", condCalls, 2)
+		} else {
+			if got, want := gotOld1, "bar"; got != want {
+				t.Errorf("wrong old value %q on first call; want %q", got, want)
+			}
+			if got, want := gotNew1, "baz"; got != want {
+				t.Errorf("wrong new value %q on first call; want %q", got, want)
+			}
+			if got, want := gotOld2, ""; got != want {
+				t.Errorf("wrong old value %q on first call; want %q", got, want)
+			}
+			if got, want := gotNew2, "baz"; got != want {
+				t.Errorf("wrong new value %q on first call; want %q", got, want)
+			}
+		}
+
+		if !diff.Attributes["foo"].RequiresNew {
+			t.Error("Attribute 'foo' is not marked as RequiresNew")
+		}
+	})
+	t.Run("false", func(t *testing.T) {
+		var condCalls int
+		var gotOld, gotNew string
+
+		provider := testProvider(
+			map[string]*schema.Schema{
+				"foo": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+			ForceNewIf("foo", func(d *schema.ResourceDiff, meta interface{}) bool {
+				condCalls++
+				old, new := d.GetChange("foo")
+				gotOld = old.(string)
+				gotNew = new.(string)
+
+				return false
+			}),
+		)
+
+		diff, err := testDiff(
+			provider,
+			map[string]string{
+				"foo": "bar",
+			},
+			map[string]string{
+				"foo": "baz",
+			},
+		)
+
+		if err != nil {
+			t.Fatalf("Diff failed with error: %s", err)
+		}
+
+		if condCalls != 1 {
+			t.Fatalf("Wrong number of conditional callback calls %d; want %d", condCalls, 1)
+		} else {
+			if got, want := gotOld, "bar"; got != want {
+				t.Errorf("wrong old value %q on first call; want %q", got, want)
+			}
+			if got, want := gotNew, "baz"; got != want {
+				t.Errorf("wrong new value %q on first call; want %q", got, want)
+			}
+		}
+
+		if diff.Attributes["foo"].RequiresNew {
+			t.Error("Attribute 'foo' is marked as RequiresNew, but should not be")
+		}
+	})
+}
+
+func TestForceNewIfChange(t *testing.T) {
+	t.Run("true", func(t *testing.T) {
+		var condCalls int
+		var gotOld1, gotNew1, gotOld2, gotNew2 string
+
+		provider := testProvider(
+			map[string]*schema.Schema{
+				"foo": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+			ForceNewIfChange("foo", func(old, new, meta interface{}) bool {
+				// When we set "ForceNew", our CustomizeDiff function is actually
+				// called a second time to construct the "create" portion of
+				// the replace diff. On the second call, the old value is masked
+				// as "" to suggest that the object is being created rather than
+				// updated.
+
+				condCalls++
+
+				switch condCalls {
+				case 1:
+					gotOld1 = old.(string)
+					gotNew1 = new.(string)
+				case 2:
+					gotOld2 = old.(string)
+					gotNew2 = new.(string)
+				}
+
+				return true
+			}),
+		)
+
+		diff, err := testDiff(
+			provider,
+			map[string]string{
+				"foo": "bar",
+			},
+			map[string]string{
+				"foo": "baz",
+			},
+		)
+
+		if err != nil {
+			t.Fatalf("Diff failed with error: %s", err)
+		}
+
+		if condCalls != 2 {
+			t.Fatalf("Wrong number of conditional callback calls %d; want %d", condCalls, 2)
+		} else {
+			if got, want := gotOld1, "bar"; got != want {
+				t.Errorf("wrong old value %q on first call; want %q", got, want)
+			}
+			if got, want := gotNew1, "baz"; got != want {
+				t.Errorf("wrong new value %q on first call; want %q", got, want)
+			}
+			if got, want := gotOld2, ""; got != want {
+				t.Errorf("wrong old value %q on first call; want %q", got, want)
+			}
+			if got, want := gotNew2, "baz"; got != want {
+				t.Errorf("wrong new value %q on first call; want %q", got, want)
+			}
+		}
+
+		if !diff.Attributes["foo"].RequiresNew {
+			t.Error("Attribute 'foo' is not marked as RequiresNew")
+		}
+	})
+	t.Run("false", func(t *testing.T) {
+		var condCalls int
+		var gotOld, gotNew string
+
+		provider := testProvider(
+			map[string]*schema.Schema{
+				"foo": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+			ForceNewIfChange("foo", func(old, new, meta interface{}) bool {
+				condCalls++
+				gotOld = old.(string)
+				gotNew = new.(string)
+
+				return false
+			}),
+		)
+
+		diff, err := testDiff(
+			provider,
+			map[string]string{
+				"foo": "bar",
+			},
+			map[string]string{
+				"foo": "baz",
+			},
+		)
+
+		if err != nil {
+			t.Fatalf("Diff failed with error: %s", err)
+		}
+
+		if condCalls != 1 {
+			t.Fatalf("Wrong number of conditional callback calls %d; want %d", condCalls, 1)
+		} else {
+			if got, want := gotOld, "bar"; got != want {
+				t.Errorf("wrong old value %q on first call; want %q", got, want)
+			}
+			if got, want := gotNew, "baz"; got != want {
+				t.Errorf("wrong new value %q on first call; want %q", got, want)
+			}
+		}
+
+		if diff.Attributes["foo"].RequiresNew {
+			t.Error("Attribute 'foo' is marked as RequiresNew, but should not be")
+		}
+	})
+}

--- a/vendor/github.com/hashicorp/terraform/helper/customdiff/testing_test.go
+++ b/vendor/github.com/hashicorp/terraform/helper/customdiff/testing_test.go
@@ -1,0 +1,38 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func testProvider(s map[string]*schema.Schema, cd schema.CustomizeDiffFunc) terraform.ResourceProvider {
+	return &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"test": {
+				Schema:        s,
+				CustomizeDiff: cd,
+			},
+		},
+	}
+}
+
+func testDiff(provider terraform.ResourceProvider, old, new map[string]string) (*terraform.InstanceDiff, error) {
+	newI := make(map[string]interface{}, len(new))
+	for k, v := range new {
+		newI[k] = v
+	}
+
+	return provider.Diff(
+		&terraform.InstanceInfo{
+			Id:         "test",
+			Type:       "test",
+			ModulePath: []string{},
+		},
+		&terraform.InstanceState{
+			Attributes: old,
+		},
+		&terraform.ResourceConfig{
+			Config: newI,
+		},
+	)
+}

--- a/vendor/github.com/hashicorp/terraform/helper/customdiff/validate.go
+++ b/vendor/github.com/hashicorp/terraform/helper/customdiff/validate.go
@@ -1,0 +1,38 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// ValueChangeValidationFunc is a function type that validates the difference
+// (or lack thereof) between two values, returning an error if the change
+// is invalid.
+type ValueChangeValidationFunc func(old, new, meta interface{}) error
+
+// ValueValidationFunc is a function type that validates a particular value,
+// returning an error if the value is invalid.
+type ValueValidationFunc func(value, meta interface{}) error
+
+// ValidateChange returns a CustomizeDiffFunc that applies the given validation
+// function to the change for the given key, returning any error produced.
+func ValidateChange(key string, f ValueChangeValidationFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		return f(old, new, meta)
+	}
+}
+
+// ValidateValue returns a CustomizeDiffFunc that applies the given validation
+// function to value of the given key, returning any error produced.
+//
+// This should generally not be used since it is functionally equivalent to
+// a validation function applied directly to the schema attribute in question,
+// but is provided for situations where composing multiple CustomizeDiffFuncs
+// together makes intent clearer than spreading that validation across the
+// schema.
+func ValidateValue(key string, f ValueValidationFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		val := d.Get(key)
+		return f(val, meta)
+	}
+}

--- a/vendor/github.com/hashicorp/terraform/helper/customdiff/validate_test.go
+++ b/vendor/github.com/hashicorp/terraform/helper/customdiff/validate_test.go
@@ -1,0 +1,98 @@
+package customdiff
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func TestValidateChange(t *testing.T) {
+	var called bool
+	var gotOld, gotNew string
+
+	provider := testProvider(
+		map[string]*schema.Schema{
+			"foo": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+		ValidateChange("foo", func(old, new, meta interface{}) error {
+			called = true
+			gotOld = old.(string)
+			gotNew = new.(string)
+			return errors.New("bad")
+		}),
+	)
+
+	_, err := testDiff(
+		provider,
+		map[string]string{
+			"foo": "bar",
+		},
+		map[string]string{
+			"foo": "baz",
+		},
+	)
+
+	if err == nil {
+		t.Fatalf("Diff succeeded; want error")
+	}
+	if got, want := err.Error(), "bad"; got != want {
+		t.Fatalf("wrong error message %q; want %q", got, want)
+	}
+
+	if !called {
+		t.Fatal("ValidateChange callback was not called")
+	}
+	if got, want := gotOld, "bar"; got != want {
+		t.Errorf("wrong old value %q; want %q", got, want)
+	}
+	if got, want := gotNew, "baz"; got != want {
+		t.Errorf("wrong new value %q; want %q", got, want)
+	}
+}
+
+func TestValidateValue(t *testing.T) {
+	var called bool
+	var gotValue string
+
+	provider := testProvider(
+		map[string]*schema.Schema{
+			"foo": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+		ValidateValue("foo", func(value, meta interface{}) error {
+			called = true
+			gotValue = value.(string)
+			return errors.New("bad")
+		}),
+	)
+
+	_, err := testDiff(
+		provider,
+		map[string]string{
+			"foo": "bar",
+		},
+		map[string]string{
+			"foo": "baz",
+		},
+	)
+
+	if err == nil {
+		t.Fatalf("Diff succeeded; want error")
+	}
+	if got, want := err.Error(), "bad"; got != want {
+		t.Fatalf("wrong error message %q; want %q", got, want)
+	}
+
+	if !called {
+		t.Fatal("ValidateValue callback was not called")
+	}
+	if got, want := gotValue, "baz"; got != want {
+		t.Errorf("wrong value %q; want %q", got, want)
+	}
+}

--- a/vendor/gopkg.in/ini.v1/.gitignore
+++ b/vendor/gopkg.in/ini.v1/.gitignore
@@ -1,0 +1,6 @@
+testdata/conf_out.ini
+ini.sublime-project
+ini.sublime-workspace
+testdata/conf_reflect.ini
+.idea
+/.vscode

--- a/vendor/gopkg.in/ini.v1/.travis.yml
+++ b/vendor/gopkg.in/ini.v1/.travis.yml
@@ -1,0 +1,20 @@
+sudo: false
+language: go
+go:
+  - 1.6.x
+  - 1.7.x
+  - 1.8.x
+  - 1.9.x
+  - 1.10.x
+  - 1.11.x
+  - 1.12.x
+  - 1.13.x
+
+install: skip
+script:
+  - go get golang.org/x/tools/cmd/cover
+  - go get github.com/smartystreets/goconvey
+  - mkdir -p $HOME/gopath/src/gopkg.in
+  - ln -s $HOME/gopath/src/github.com/go-ini/ini $HOME/gopath/src/gopkg.in/ini.v1
+  - cd $HOME/gopath/src/gopkg.in/ini.v1
+  - go test -v -cover -race

--- a/vendor/gopkg.in/ini.v1/LICENSE
+++ b/vendor/gopkg.in/ini.v1/LICENSE
@@ -1,0 +1,191 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification within
+third-party archives.
+
+   Copyright 2014 Unknwon
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/gopkg.in/ini.v1/Makefile
+++ b/vendor/gopkg.in/ini.v1/Makefile
@@ -1,0 +1,15 @@
+.PHONY: build test bench vet coverage
+
+build: vet bench
+
+test:
+	go test -v -cover -race
+
+bench:
+	go test -v -cover -race -test.bench=. -test.benchmem
+
+vet:
+	go vet
+
+coverage:
+	go test -coverprofile=c.out && go tool cover -html=c.out && rm c.out

--- a/vendor/gopkg.in/ini.v1/README.md
+++ b/vendor/gopkg.in/ini.v1/README.md
@@ -1,0 +1,39 @@
+# INI
+
+[![Build Status](https://img.shields.io/travis/go-ini/ini/master.svg?style=for-the-badge&logo=travis)](https://travis-ci.org/go-ini/ini) [![Sourcegraph](https://img.shields.io/badge/view%20on-Sourcegraph-brightgreen.svg?style=for-the-badge&logo=sourcegraph)](https://sourcegraph.com/github.com/go-ini/ini)
+
+![](https://avatars0.githubusercontent.com/u/10216035?v=3&s=200)
+
+Package ini provides INI file read and write functionality in Go.
+
+## Features
+
+- Load from multiple data sources(`[]byte`, file and `io.ReadCloser`) with overwrites.
+- Read with recursion values.
+- Read with parent-child sections.
+- Read with auto-increment key names.
+- Read with multiple-line values.
+- Read with tons of helper methods.
+- Read and convert values to Go types.
+- Read and **WRITE** comments of sections and keys.
+- Manipulate sections, keys and comments with ease.
+- Keep sections and keys in order as you parse and save.
+
+## Installation
+
+The minimum requirement of Go is **1.6**.
+
+```sh
+$ go get gopkg.in/ini.v1
+```
+
+Please add `-u` flag to update in the future.
+
+## Getting Help
+
+- [Getting Started](https://ini.unknwon.io/docs/intro/getting_started)
+- [API Documentation](https://gowalker.org/gopkg.in/ini.v1)
+
+## License
+
+This project is under Apache v2 License. See the [LICENSE](LICENSE) file for the full license text.

--- a/vendor/gopkg.in/ini.v1/data_source.go
+++ b/vendor/gopkg.in/ini.v1/data_source.go
@@ -1,0 +1,74 @@
+// Copyright 2019 Unknwon
+//
+// Licensed under the Apache License, Version 2.0 (the "License"): you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package ini
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+var (
+	_ dataSource = (*sourceFile)(nil)
+	_ dataSource = (*sourceData)(nil)
+	_ dataSource = (*sourceReadCloser)(nil)
+)
+
+// dataSource is an interface that returns object which can be read and closed.
+type dataSource interface {
+	ReadCloser() (io.ReadCloser, error)
+}
+
+// sourceFile represents an object that contains content on the local file system.
+type sourceFile struct {
+	name string
+}
+
+func (s sourceFile) ReadCloser() (_ io.ReadCloser, err error) {
+	return os.Open(s.name)
+}
+
+// sourceData represents an object that contains content in memory.
+type sourceData struct {
+	data []byte
+}
+
+func (s *sourceData) ReadCloser() (io.ReadCloser, error) {
+	return ioutil.NopCloser(bytes.NewReader(s.data)), nil
+}
+
+// sourceReadCloser represents an input stream with Close method.
+type sourceReadCloser struct {
+	reader io.ReadCloser
+}
+
+func (s *sourceReadCloser) ReadCloser() (io.ReadCloser, error) {
+	return s.reader, nil
+}
+
+func parseDataSource(source interface{}) (dataSource, error) {
+	switch s := source.(type) {
+	case string:
+		return sourceFile{s}, nil
+	case []byte:
+		return &sourceData{s}, nil
+	case io.ReadCloser:
+		return &sourceReadCloser{s}, nil
+	default:
+		return nil, fmt.Errorf("error parsing data source: unknown type %q", s)
+	}
+}

--- a/vendor/gopkg.in/ini.v1/deprecated.go
+++ b/vendor/gopkg.in/ini.v1/deprecated.go
@@ -1,0 +1,25 @@
+// Copyright 2019 Unknwon
+//
+// Licensed under the Apache License, Version 2.0 (the "License"): you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package ini
+
+const (
+	// Deprecated: Use "DefaultSection" instead.
+	DEFAULT_SECTION = DefaultSection
+)
+
+var (
+	// Deprecated: AllCapsUnderscore converts to format ALL_CAPS_UNDERSCORE.
+	AllCapsUnderscore = SnackCase
+)

--- a/vendor/gopkg.in/ini.v1/error.go
+++ b/vendor/gopkg.in/ini.v1/error.go
@@ -1,0 +1,34 @@
+// Copyright 2016 Unknwon
+//
+// Licensed under the Apache License, Version 2.0 (the "License"): you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package ini
+
+import (
+	"fmt"
+)
+
+// ErrDelimiterNotFound indicates the error type of no delimiter is found which there should be one.
+type ErrDelimiterNotFound struct {
+	Line string
+}
+
+// IsErrDelimiterNotFound returns true if the given error is an instance of ErrDelimiterNotFound.
+func IsErrDelimiterNotFound(err error) bool {
+	_, ok := err.(ErrDelimiterNotFound)
+	return ok
+}
+
+func (err ErrDelimiterNotFound) Error() string {
+	return fmt.Sprintf("key-value delimiter not found: %s", err.Line)
+}

--- a/vendor/gopkg.in/ini.v1/file.go
+++ b/vendor/gopkg.in/ini.v1/file.go
@@ -1,0 +1,418 @@
+// Copyright 2017 Unknwon
+//
+// Licensed under the Apache License, Version 2.0 (the "License"): you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package ini
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+	"sync"
+)
+
+// File represents a combination of a or more INI file(s) in memory.
+type File struct {
+	options     LoadOptions
+	dataSources []dataSource
+
+	// Should make things safe, but sometimes doesn't matter.
+	BlockMode bool
+	lock      sync.RWMutex
+
+	// To keep data in order.
+	sectionList []string
+	// Actual data is stored here.
+	sections map[string]*Section
+
+	NameMapper
+	ValueMapper
+}
+
+// newFile initializes File object with given data sources.
+func newFile(dataSources []dataSource, opts LoadOptions) *File {
+	if len(opts.KeyValueDelimiters) == 0 {
+		opts.KeyValueDelimiters = "=:"
+	}
+	return &File{
+		BlockMode:   true,
+		dataSources: dataSources,
+		sections:    make(map[string]*Section),
+		sectionList: make([]string, 0, 10),
+		options:     opts,
+	}
+}
+
+// Empty returns an empty file object.
+func Empty() *File {
+	// Ignore error here, we sure our data is good.
+	f, _ := Load([]byte(""))
+	return f
+}
+
+// NewSection creates a new section.
+func (f *File) NewSection(name string) (*Section, error) {
+	if len(name) == 0 {
+		return nil, errors.New("error creating new section: empty section name")
+	} else if f.options.Insensitive && name != DefaultSection {
+		name = strings.ToLower(name)
+	}
+
+	if f.BlockMode {
+		f.lock.Lock()
+		defer f.lock.Unlock()
+	}
+
+	if inSlice(name, f.sectionList) {
+		return f.sections[name], nil
+	}
+
+	f.sectionList = append(f.sectionList, name)
+	f.sections[name] = newSection(f, name)
+	return f.sections[name], nil
+}
+
+// NewRawSection creates a new section with an unparseable body.
+func (f *File) NewRawSection(name, body string) (*Section, error) {
+	section, err := f.NewSection(name)
+	if err != nil {
+		return nil, err
+	}
+
+	section.isRawSection = true
+	section.rawBody = body
+	return section, nil
+}
+
+// NewSections creates a list of sections.
+func (f *File) NewSections(names ...string) (err error) {
+	for _, name := range names {
+		if _, err = f.NewSection(name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetSection returns section by given name.
+func (f *File) GetSection(name string) (*Section, error) {
+	if len(name) == 0 {
+		name = DefaultSection
+	}
+	if f.options.Insensitive {
+		name = strings.ToLower(name)
+	}
+
+	if f.BlockMode {
+		f.lock.RLock()
+		defer f.lock.RUnlock()
+	}
+
+	sec := f.sections[name]
+	if sec == nil {
+		return nil, fmt.Errorf("section '%s' does not exist", name)
+	}
+	return sec, nil
+}
+
+// Section assumes named section exists and returns a zero-value when not.
+func (f *File) Section(name string) *Section {
+	sec, err := f.GetSection(name)
+	if err != nil {
+		// Note: It's OK here because the only possible error is empty section name,
+		// but if it's empty, this piece of code won't be executed.
+		sec, _ = f.NewSection(name)
+		return sec
+	}
+	return sec
+}
+
+// Sections returns a list of Section stored in the current instance.
+func (f *File) Sections() []*Section {
+	if f.BlockMode {
+		f.lock.RLock()
+		defer f.lock.RUnlock()
+	}
+
+	sections := make([]*Section, len(f.sectionList))
+	for i, name := range f.sectionList {
+		sections[i] = f.sections[name]
+	}
+	return sections
+}
+
+// ChildSections returns a list of child sections of given section name.
+func (f *File) ChildSections(name string) []*Section {
+	return f.Section(name).ChildSections()
+}
+
+// SectionStrings returns list of section names.
+func (f *File) SectionStrings() []string {
+	list := make([]string, len(f.sectionList))
+	copy(list, f.sectionList)
+	return list
+}
+
+// DeleteSection deletes a section.
+func (f *File) DeleteSection(name string) {
+	if f.BlockMode {
+		f.lock.Lock()
+		defer f.lock.Unlock()
+	}
+
+	if len(name) == 0 {
+		name = DefaultSection
+	}
+
+	for i, s := range f.sectionList {
+		if s == name {
+			f.sectionList = append(f.sectionList[:i], f.sectionList[i+1:]...)
+			delete(f.sections, name)
+			return
+		}
+	}
+}
+
+func (f *File) reload(s dataSource) error {
+	r, err := s.ReadCloser()
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	return f.parse(r)
+}
+
+// Reload reloads and parses all data sources.
+func (f *File) Reload() (err error) {
+	for _, s := range f.dataSources {
+		if err = f.reload(s); err != nil {
+			// In loose mode, we create an empty default section for nonexistent files.
+			if os.IsNotExist(err) && f.options.Loose {
+				f.parse(bytes.NewBuffer(nil))
+				continue
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+// Append appends one or more data sources and reloads automatically.
+func (f *File) Append(source interface{}, others ...interface{}) error {
+	ds, err := parseDataSource(source)
+	if err != nil {
+		return err
+	}
+	f.dataSources = append(f.dataSources, ds)
+	for _, s := range others {
+		ds, err = parseDataSource(s)
+		if err != nil {
+			return err
+		}
+		f.dataSources = append(f.dataSources, ds)
+	}
+	return f.Reload()
+}
+
+func (f *File) writeToBuffer(indent string) (*bytes.Buffer, error) {
+	equalSign := DefaultFormatLeft + "=" + DefaultFormatRight
+
+	if PrettyFormat || PrettyEqual {
+		equalSign = " = "
+	}
+
+	// Use buffer to make sure target is safe until finish encoding.
+	buf := bytes.NewBuffer(nil)
+	for i, sname := range f.sectionList {
+		sec := f.Section(sname)
+		if len(sec.Comment) > 0 {
+			// Support multiline comments
+			lines := strings.Split(sec.Comment, LineBreak)
+			for i := range lines {
+				if lines[i][0] != '#' && lines[i][0] != ';' {
+					lines[i] = "; " + lines[i]
+				} else {
+					lines[i] = lines[i][:1] + " " + strings.TrimSpace(lines[i][1:])
+				}
+
+				if _, err := buf.WriteString(lines[i] + LineBreak); err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		if i > 0 || DefaultHeader {
+			if _, err := buf.WriteString("[" + sname + "]" + LineBreak); err != nil {
+				return nil, err
+			}
+		} else {
+			// Write nothing if default section is empty
+			if len(sec.keyList) == 0 {
+				continue
+			}
+		}
+
+		if sec.isRawSection {
+			if _, err := buf.WriteString(sec.rawBody); err != nil {
+				return nil, err
+			}
+
+			if PrettySection {
+				// Put a line between sections
+				if _, err := buf.WriteString(LineBreak); err != nil {
+					return nil, err
+				}
+			}
+			continue
+		}
+
+		// Count and generate alignment length and buffer spaces using the
+		// longest key. Keys may be modifed if they contain certain characters so
+		// we need to take that into account in our calculation.
+		alignLength := 0
+		if PrettyFormat {
+			for _, kname := range sec.keyList {
+				keyLength := len(kname)
+				// First case will surround key by ` and second by """
+				if strings.Contains(kname, "\"") || strings.ContainsAny(kname, f.options.KeyValueDelimiters) {
+					keyLength += 2
+				} else if strings.Contains(kname, "`") {
+					keyLength += 6
+				}
+
+				if keyLength > alignLength {
+					alignLength = keyLength
+				}
+			}
+		}
+		alignSpaces := bytes.Repeat([]byte(" "), alignLength)
+
+	KeyList:
+		for _, kname := range sec.keyList {
+			key := sec.Key(kname)
+			if len(key.Comment) > 0 {
+				if len(indent) > 0 && sname != DefaultSection {
+					buf.WriteString(indent)
+				}
+
+				// Support multiline comments
+				lines := strings.Split(key.Comment, LineBreak)
+				for i := range lines {
+					if lines[i][0] != '#' && lines[i][0] != ';' {
+						lines[i] = "; " + strings.TrimSpace(lines[i])
+					} else {
+						lines[i] = lines[i][:1] + " " + strings.TrimSpace(lines[i][1:])
+					}
+
+					if _, err := buf.WriteString(lines[i] + LineBreak); err != nil {
+						return nil, err
+					}
+				}
+			}
+
+			if len(indent) > 0 && sname != DefaultSection {
+				buf.WriteString(indent)
+			}
+
+			switch {
+			case key.isAutoIncrement:
+				kname = "-"
+			case strings.Contains(kname, "\"") || strings.ContainsAny(kname, f.options.KeyValueDelimiters):
+				kname = "`" + kname + "`"
+			case strings.Contains(kname, "`"):
+				kname = `"""` + kname + `"""`
+			}
+
+			for _, val := range key.ValueWithShadows() {
+				if _, err := buf.WriteString(kname); err != nil {
+					return nil, err
+				}
+
+				if key.isBooleanType {
+					if kname != sec.keyList[len(sec.keyList)-1] {
+						buf.WriteString(LineBreak)
+					}
+					continue KeyList
+				}
+
+				// Write out alignment spaces before "=" sign
+				if PrettyFormat {
+					buf.Write(alignSpaces[:alignLength-len(kname)])
+				}
+
+				// In case key value contains "\n", "`", "\"", "#" or ";"
+				if strings.ContainsAny(val, "\n`") {
+					val = `"""` + val + `"""`
+				} else if !f.options.IgnoreInlineComment && strings.ContainsAny(val, "#;") {
+					val = "`" + val + "`"
+				}
+				if _, err := buf.WriteString(equalSign + val + LineBreak); err != nil {
+					return nil, err
+				}
+			}
+
+			for _, val := range key.nestedValues {
+				if _, err := buf.WriteString(indent + "  " + val + LineBreak); err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		if PrettySection {
+			// Put a line between sections
+			if _, err := buf.WriteString(LineBreak); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return buf, nil
+}
+
+// WriteToIndent writes content into io.Writer with given indention.
+// If PrettyFormat has been set to be true,
+// it will align "=" sign with spaces under each section.
+func (f *File) WriteToIndent(w io.Writer, indent string) (int64, error) {
+	buf, err := f.writeToBuffer(indent)
+	if err != nil {
+		return 0, err
+	}
+	return buf.WriteTo(w)
+}
+
+// WriteTo writes file content into io.Writer.
+func (f *File) WriteTo(w io.Writer) (int64, error) {
+	return f.WriteToIndent(w, "")
+}
+
+// SaveToIndent writes content to file system with given value indention.
+func (f *File) SaveToIndent(filename, indent string) error {
+	// Note: Because we are truncating with os.Create,
+	// 	so it's safer to save to a temporary file location and rename afte done.
+	buf, err := f.writeToBuffer(indent)
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(filename, buf.Bytes(), 0666)
+}
+
+// SaveTo writes content to file system.
+func (f *File) SaveTo(filename string) error {
+	return f.SaveToIndent(filename, "")
+}

--- a/vendor/gopkg.in/ini.v1/helper.go
+++ b/vendor/gopkg.in/ini.v1/helper.go
@@ -1,0 +1,24 @@
+// Copyright 2019 Unknwon
+//
+// Licensed under the Apache License, Version 2.0 (the "License"): you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package ini
+
+func inSlice(str string, s []string) bool {
+	for _, v := range s {
+		if str == v {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/gopkg.in/ini.v1/ini.go
+++ b/vendor/gopkg.in/ini.v1/ini.go
@@ -1,0 +1,166 @@
+// +build go1.6
+
+// Copyright 2014 Unknwon
+//
+// Licensed under the Apache License, Version 2.0 (the "License"): you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+// Package ini provides INI file read and write functionality in Go.
+package ini
+
+import (
+	"regexp"
+	"runtime"
+)
+
+const (
+	// DefaultSection is the name of default section. You can use this constant or the string literal.
+	// In most of cases, an empty string is all you need to access the section.
+	DefaultSection = "DEFAULT"
+
+	// Maximum allowed depth when recursively substituing variable names.
+	depthValues = 99
+	version     = "1.52.0"
+)
+
+// Version returns current package version literal.
+func Version() string {
+	return version
+}
+
+var (
+	// LineBreak is the delimiter to determine or compose a new line.
+	// This variable will be changed to "\r\n" automatically on Windows at package init time.
+	LineBreak = "\n"
+
+	// Variable regexp pattern: %(variable)s
+	varPattern = regexp.MustCompile(`%\(([^)]+)\)s`)
+
+	// DefaultHeader explicitly writes default section header.
+	DefaultHeader = false
+
+	// PrettySection indicates whether to put a line between sections.
+	PrettySection = true
+	// PrettyFormat indicates whether to align "=" sign with spaces to produce pretty output
+	// or reduce all possible spaces for compact format.
+	PrettyFormat = true
+	// PrettyEqual places spaces around "=" sign even when PrettyFormat is false.
+	PrettyEqual = false
+	// DefaultFormatLeft places custom spaces on the left when PrettyFormat and PrettyEqual are both disabled.
+	DefaultFormatLeft = ""
+	// DefaultFormatRight places custom spaces on the right when PrettyFormat and PrettyEqual are both disabled.
+	DefaultFormatRight = ""
+)
+
+func init() {
+	if runtime.GOOS == "windows" {
+		LineBreak = "\r\n"
+	}
+}
+
+// LoadOptions contains all customized options used for load data source(s).
+type LoadOptions struct {
+	// Loose indicates whether the parser should ignore nonexistent files or return error.
+	Loose bool
+	// Insensitive indicates whether the parser forces all section and key names to lowercase.
+	Insensitive bool
+	// IgnoreContinuation indicates whether to ignore continuation lines while parsing.
+	IgnoreContinuation bool
+	// IgnoreInlineComment indicates whether to ignore comments at the end of value and treat it as part of value.
+	IgnoreInlineComment bool
+	// SkipUnrecognizableLines indicates whether to skip unrecognizable lines that do not conform to key/value pairs.
+	SkipUnrecognizableLines bool
+	// AllowBooleanKeys indicates whether to allow boolean type keys or treat as value is missing.
+	// This type of keys are mostly used in my.cnf.
+	AllowBooleanKeys bool
+	// AllowShadows indicates whether to keep track of keys with same name under same section.
+	AllowShadows bool
+	// AllowNestedValues indicates whether to allow AWS-like nested values.
+	// Docs: http://docs.aws.amazon.com/cli/latest/topic/config-vars.html#nested-values
+	AllowNestedValues bool
+	// AllowPythonMultilineValues indicates whether to allow Python-like multi-line values.
+	// Docs: https://docs.python.org/3/library/configparser.html#supported-ini-file-structure
+	// Relevant quote:  Values can also span multiple lines, as long as they are indented deeper
+	// than the first line of the value.
+	AllowPythonMultilineValues bool
+	// SpaceBeforeInlineComment indicates whether to allow comment symbols (\# and \;) inside value.
+	// Docs: https://docs.python.org/2/library/configparser.html
+	// Quote: Comments may appear on their own in an otherwise empty line, or may be entered in lines holding values or section names.
+	// In the latter case, they need to be preceded by a whitespace character to be recognized as a comment.
+	SpaceBeforeInlineComment bool
+	// UnescapeValueDoubleQuotes indicates whether to unescape double quotes inside value to regular format
+	// when value is surrounded by double quotes, e.g. key="a \"value\"" => key=a "value"
+	UnescapeValueDoubleQuotes bool
+	// UnescapeValueCommentSymbols indicates to unescape comment symbols (\# and \;) inside value to regular format
+	// when value is NOT surrounded by any quotes.
+	// Note: UNSTABLE, behavior might change to only unescape inside double quotes but may noy necessary at all.
+	UnescapeValueCommentSymbols bool
+	// UnparseableSections stores a list of blocks that are allowed with raw content which do not otherwise
+	// conform to key/value pairs. Specify the names of those blocks here.
+	UnparseableSections []string
+	// KeyValueDelimiters is the sequence of delimiters that are used to separate key and value. By default, it is "=:".
+	KeyValueDelimiters string
+	// PreserveSurroundedQuote indicates whether to preserve surrounded quote (single and double quotes).
+	PreserveSurroundedQuote bool
+	// DebugFunc is called to collect debug information (currently only useful to debug parsing Python-style multiline values).
+	DebugFunc DebugFunc
+	// ReaderBufferSize is the buffer size of the reader in bytes.
+	ReaderBufferSize int
+}
+
+// DebugFunc is the type of function called to log parse events.
+type DebugFunc func(message string)
+
+// LoadSources allows caller to apply customized options for loading from data source(s).
+func LoadSources(opts LoadOptions, source interface{}, others ...interface{}) (_ *File, err error) {
+	sources := make([]dataSource, len(others)+1)
+	sources[0], err = parseDataSource(source)
+	if err != nil {
+		return nil, err
+	}
+	for i := range others {
+		sources[i+1], err = parseDataSource(others[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	f := newFile(sources, opts)
+	if err = f.Reload(); err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+// Load loads and parses from INI data sources.
+// Arguments can be mixed of file name with string type, or raw data in []byte.
+// It will return error if list contains nonexistent files.
+func Load(source interface{}, others ...interface{}) (*File, error) {
+	return LoadSources(LoadOptions{}, source, others...)
+}
+
+// LooseLoad has exactly same functionality as Load function
+// except it ignores nonexistent files instead of returning error.
+func LooseLoad(source interface{}, others ...interface{}) (*File, error) {
+	return LoadSources(LoadOptions{Loose: true}, source, others...)
+}
+
+// InsensitiveLoad has exactly same functionality as Load function
+// except it forces all section and key names to be lowercased.
+func InsensitiveLoad(source interface{}, others ...interface{}) (*File, error) {
+	return LoadSources(LoadOptions{Insensitive: true}, source, others...)
+}
+
+// ShadowLoad has exactly same functionality as Load function
+// except it allows have shadow keys.
+func ShadowLoad(source interface{}, others ...interface{}) (*File, error) {
+	return LoadSources(LoadOptions{AllowShadows: true}, source, others...)
+}

--- a/vendor/gopkg.in/ini.v1/key.go
+++ b/vendor/gopkg.in/ini.v1/key.go
@@ -1,0 +1,801 @@
+// Copyright 2014 Unknwon
+//
+// Licensed under the Apache License, Version 2.0 (the "License"): you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package ini
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Key represents a key under a section.
+type Key struct {
+	s               *Section
+	Comment         string
+	name            string
+	value           string
+	isAutoIncrement bool
+	isBooleanType   bool
+
+	isShadow bool
+	shadows  []*Key
+
+	nestedValues []string
+}
+
+// newKey simply return a key object with given values.
+func newKey(s *Section, name, val string) *Key {
+	return &Key{
+		s:     s,
+		name:  name,
+		value: val,
+	}
+}
+
+func (k *Key) addShadow(val string) error {
+	if k.isShadow {
+		return errors.New("cannot add shadow to another shadow key")
+	} else if k.isAutoIncrement || k.isBooleanType {
+		return errors.New("cannot add shadow to auto-increment or boolean key")
+	}
+
+	// Deduplicate shadows based on their values.
+	if k.value == val {
+		return nil
+	}
+	for i := range k.shadows {
+		if k.shadows[i].value == val {
+			return nil
+		}
+	}
+
+	shadow := newKey(k.s, k.name, val)
+	shadow.isShadow = true
+	k.shadows = append(k.shadows, shadow)
+	return nil
+}
+
+// AddShadow adds a new shadow key to itself.
+func (k *Key) AddShadow(val string) error {
+	if !k.s.f.options.AllowShadows {
+		return errors.New("shadow key is not allowed")
+	}
+	return k.addShadow(val)
+}
+
+func (k *Key) addNestedValue(val string) error {
+	if k.isAutoIncrement || k.isBooleanType {
+		return errors.New("cannot add nested value to auto-increment or boolean key")
+	}
+
+	k.nestedValues = append(k.nestedValues, val)
+	return nil
+}
+
+// AddNestedValue adds a nested value to the key.
+func (k *Key) AddNestedValue(val string) error {
+	if !k.s.f.options.AllowNestedValues {
+		return errors.New("nested value is not allowed")
+	}
+	return k.addNestedValue(val)
+}
+
+// ValueMapper represents a mapping function for values, e.g. os.ExpandEnv
+type ValueMapper func(string) string
+
+// Name returns name of key.
+func (k *Key) Name() string {
+	return k.name
+}
+
+// Value returns raw value of key for performance purpose.
+func (k *Key) Value() string {
+	return k.value
+}
+
+// ValueWithShadows returns raw values of key and its shadows if any.
+func (k *Key) ValueWithShadows() []string {
+	if len(k.shadows) == 0 {
+		return []string{k.value}
+	}
+	vals := make([]string, len(k.shadows)+1)
+	vals[0] = k.value
+	for i := range k.shadows {
+		vals[i+1] = k.shadows[i].value
+	}
+	return vals
+}
+
+// NestedValues returns nested values stored in the key.
+// It is possible returned value is nil if no nested values stored in the key.
+func (k *Key) NestedValues() []string {
+	return k.nestedValues
+}
+
+// transformValue takes a raw value and transforms to its final string.
+func (k *Key) transformValue(val string) string {
+	if k.s.f.ValueMapper != nil {
+		val = k.s.f.ValueMapper(val)
+	}
+
+	// Fail-fast if no indicate char found for recursive value
+	if !strings.Contains(val, "%") {
+		return val
+	}
+	for i := 0; i < depthValues; i++ {
+		vr := varPattern.FindString(val)
+		if len(vr) == 0 {
+			break
+		}
+
+		// Take off leading '%(' and trailing ')s'.
+		noption := vr[2 : len(vr)-2]
+
+		// Search in the same section.
+		// If not found or found the key itself, then search again in default section.
+		nk, err := k.s.GetKey(noption)
+		if err != nil || k == nk {
+			nk, _ = k.s.f.Section("").GetKey(noption)
+			if nk == nil {
+				// Stop when no results found in the default section,
+				// and returns the value as-is.
+				break
+			}
+		}
+
+		// Substitute by new value and take off leading '%(' and trailing ')s'.
+		val = strings.Replace(val, vr, nk.value, -1)
+	}
+	return val
+}
+
+// String returns string representation of value.
+func (k *Key) String() string {
+	return k.transformValue(k.value)
+}
+
+// Validate accepts a validate function which can
+// return modifed result as key value.
+func (k *Key) Validate(fn func(string) string) string {
+	return fn(k.String())
+}
+
+// parseBool returns the boolean value represented by the string.
+//
+// It accepts 1, t, T, TRUE, true, True, YES, yes, Yes, y, ON, on, On,
+// 0, f, F, FALSE, false, False, NO, no, No, n, OFF, off, Off.
+// Any other value returns an error.
+func parseBool(str string) (value bool, err error) {
+	switch str {
+	case "1", "t", "T", "true", "TRUE", "True", "YES", "yes", "Yes", "y", "ON", "on", "On":
+		return true, nil
+	case "0", "f", "F", "false", "FALSE", "False", "NO", "no", "No", "n", "OFF", "off", "Off":
+		return false, nil
+	}
+	return false, fmt.Errorf("parsing \"%s\": invalid syntax", str)
+}
+
+// Bool returns bool type value.
+func (k *Key) Bool() (bool, error) {
+	return parseBool(k.String())
+}
+
+// Float64 returns float64 type value.
+func (k *Key) Float64() (float64, error) {
+	return strconv.ParseFloat(k.String(), 64)
+}
+
+// Int returns int type value.
+func (k *Key) Int() (int, error) {
+	v, err := strconv.ParseInt(k.String(), 0, 64)
+	return int(v), err
+}
+
+// Int64 returns int64 type value.
+func (k *Key) Int64() (int64, error) {
+	return strconv.ParseInt(k.String(), 0, 64)
+}
+
+// Uint returns uint type valued.
+func (k *Key) Uint() (uint, error) {
+	u, e := strconv.ParseUint(k.String(), 0, 64)
+	return uint(u), e
+}
+
+// Uint64 returns uint64 type value.
+func (k *Key) Uint64() (uint64, error) {
+	return strconv.ParseUint(k.String(), 0, 64)
+}
+
+// Duration returns time.Duration type value.
+func (k *Key) Duration() (time.Duration, error) {
+	return time.ParseDuration(k.String())
+}
+
+// TimeFormat parses with given format and returns time.Time type value.
+func (k *Key) TimeFormat(format string) (time.Time, error) {
+	return time.Parse(format, k.String())
+}
+
+// Time parses with RFC3339 format and returns time.Time type value.
+func (k *Key) Time() (time.Time, error) {
+	return k.TimeFormat(time.RFC3339)
+}
+
+// MustString returns default value if key value is empty.
+func (k *Key) MustString(defaultVal string) string {
+	val := k.String()
+	if len(val) == 0 {
+		k.value = defaultVal
+		return defaultVal
+	}
+	return val
+}
+
+// MustBool always returns value without error,
+// it returns false if error occurs.
+func (k *Key) MustBool(defaultVal ...bool) bool {
+	val, err := k.Bool()
+	if len(defaultVal) > 0 && err != nil {
+		k.value = strconv.FormatBool(defaultVal[0])
+		return defaultVal[0]
+	}
+	return val
+}
+
+// MustFloat64 always returns value without error,
+// it returns 0.0 if error occurs.
+func (k *Key) MustFloat64(defaultVal ...float64) float64 {
+	val, err := k.Float64()
+	if len(defaultVal) > 0 && err != nil {
+		k.value = strconv.FormatFloat(defaultVal[0], 'f', -1, 64)
+		return defaultVal[0]
+	}
+	return val
+}
+
+// MustInt always returns value without error,
+// it returns 0 if error occurs.
+func (k *Key) MustInt(defaultVal ...int) int {
+	val, err := k.Int()
+	if len(defaultVal) > 0 && err != nil {
+		k.value = strconv.FormatInt(int64(defaultVal[0]), 10)
+		return defaultVal[0]
+	}
+	return val
+}
+
+// MustInt64 always returns value without error,
+// it returns 0 if error occurs.
+func (k *Key) MustInt64(defaultVal ...int64) int64 {
+	val, err := k.Int64()
+	if len(defaultVal) > 0 && err != nil {
+		k.value = strconv.FormatInt(defaultVal[0], 10)
+		return defaultVal[0]
+	}
+	return val
+}
+
+// MustUint always returns value without error,
+// it returns 0 if error occurs.
+func (k *Key) MustUint(defaultVal ...uint) uint {
+	val, err := k.Uint()
+	if len(defaultVal) > 0 && err != nil {
+		k.value = strconv.FormatUint(uint64(defaultVal[0]), 10)
+		return defaultVal[0]
+	}
+	return val
+}
+
+// MustUint64 always returns value without error,
+// it returns 0 if error occurs.
+func (k *Key) MustUint64(defaultVal ...uint64) uint64 {
+	val, err := k.Uint64()
+	if len(defaultVal) > 0 && err != nil {
+		k.value = strconv.FormatUint(defaultVal[0], 10)
+		return defaultVal[0]
+	}
+	return val
+}
+
+// MustDuration always returns value without error,
+// it returns zero value if error occurs.
+func (k *Key) MustDuration(defaultVal ...time.Duration) time.Duration {
+	val, err := k.Duration()
+	if len(defaultVal) > 0 && err != nil {
+		k.value = defaultVal[0].String()
+		return defaultVal[0]
+	}
+	return val
+}
+
+// MustTimeFormat always parses with given format and returns value without error,
+// it returns zero value if error occurs.
+func (k *Key) MustTimeFormat(format string, defaultVal ...time.Time) time.Time {
+	val, err := k.TimeFormat(format)
+	if len(defaultVal) > 0 && err != nil {
+		k.value = defaultVal[0].Format(format)
+		return defaultVal[0]
+	}
+	return val
+}
+
+// MustTime always parses with RFC3339 format and returns value without error,
+// it returns zero value if error occurs.
+func (k *Key) MustTime(defaultVal ...time.Time) time.Time {
+	return k.MustTimeFormat(time.RFC3339, defaultVal...)
+}
+
+// In always returns value without error,
+// it returns default value if error occurs or doesn't fit into candidates.
+func (k *Key) In(defaultVal string, candidates []string) string {
+	val := k.String()
+	for _, cand := range candidates {
+		if val == cand {
+			return val
+		}
+	}
+	return defaultVal
+}
+
+// InFloat64 always returns value without error,
+// it returns default value if error occurs or doesn't fit into candidates.
+func (k *Key) InFloat64(defaultVal float64, candidates []float64) float64 {
+	val := k.MustFloat64()
+	for _, cand := range candidates {
+		if val == cand {
+			return val
+		}
+	}
+	return defaultVal
+}
+
+// InInt always returns value without error,
+// it returns default value if error occurs or doesn't fit into candidates.
+func (k *Key) InInt(defaultVal int, candidates []int) int {
+	val := k.MustInt()
+	for _, cand := range candidates {
+		if val == cand {
+			return val
+		}
+	}
+	return defaultVal
+}
+
+// InInt64 always returns value without error,
+// it returns default value if error occurs or doesn't fit into candidates.
+func (k *Key) InInt64(defaultVal int64, candidates []int64) int64 {
+	val := k.MustInt64()
+	for _, cand := range candidates {
+		if val == cand {
+			return val
+		}
+	}
+	return defaultVal
+}
+
+// InUint always returns value without error,
+// it returns default value if error occurs or doesn't fit into candidates.
+func (k *Key) InUint(defaultVal uint, candidates []uint) uint {
+	val := k.MustUint()
+	for _, cand := range candidates {
+		if val == cand {
+			return val
+		}
+	}
+	return defaultVal
+}
+
+// InUint64 always returns value without error,
+// it returns default value if error occurs or doesn't fit into candidates.
+func (k *Key) InUint64(defaultVal uint64, candidates []uint64) uint64 {
+	val := k.MustUint64()
+	for _, cand := range candidates {
+		if val == cand {
+			return val
+		}
+	}
+	return defaultVal
+}
+
+// InTimeFormat always parses with given format and returns value without error,
+// it returns default value if error occurs or doesn't fit into candidates.
+func (k *Key) InTimeFormat(format string, defaultVal time.Time, candidates []time.Time) time.Time {
+	val := k.MustTimeFormat(format)
+	for _, cand := range candidates {
+		if val == cand {
+			return val
+		}
+	}
+	return defaultVal
+}
+
+// InTime always parses with RFC3339 format and returns value without error,
+// it returns default value if error occurs or doesn't fit into candidates.
+func (k *Key) InTime(defaultVal time.Time, candidates []time.Time) time.Time {
+	return k.InTimeFormat(time.RFC3339, defaultVal, candidates)
+}
+
+// RangeFloat64 checks if value is in given range inclusively,
+// and returns default value if it's not.
+func (k *Key) RangeFloat64(defaultVal, min, max float64) float64 {
+	val := k.MustFloat64()
+	if val < min || val > max {
+		return defaultVal
+	}
+	return val
+}
+
+// RangeInt checks if value is in given range inclusively,
+// and returns default value if it's not.
+func (k *Key) RangeInt(defaultVal, min, max int) int {
+	val := k.MustInt()
+	if val < min || val > max {
+		return defaultVal
+	}
+	return val
+}
+
+// RangeInt64 checks if value is in given range inclusively,
+// and returns default value if it's not.
+func (k *Key) RangeInt64(defaultVal, min, max int64) int64 {
+	val := k.MustInt64()
+	if val < min || val > max {
+		return defaultVal
+	}
+	return val
+}
+
+// RangeTimeFormat checks if value with given format is in given range inclusively,
+// and returns default value if it's not.
+func (k *Key) RangeTimeFormat(format string, defaultVal, min, max time.Time) time.Time {
+	val := k.MustTimeFormat(format)
+	if val.Unix() < min.Unix() || val.Unix() > max.Unix() {
+		return defaultVal
+	}
+	return val
+}
+
+// RangeTime checks if value with RFC3339 format is in given range inclusively,
+// and returns default value if it's not.
+func (k *Key) RangeTime(defaultVal, min, max time.Time) time.Time {
+	return k.RangeTimeFormat(time.RFC3339, defaultVal, min, max)
+}
+
+// Strings returns list of string divided by given delimiter.
+func (k *Key) Strings(delim string) []string {
+	str := k.String()
+	if len(str) == 0 {
+		return []string{}
+	}
+
+	runes := []rune(str)
+	vals := make([]string, 0, 2)
+	var buf bytes.Buffer
+	escape := false
+	idx := 0
+	for {
+		if escape {
+			escape = false
+			if runes[idx] != '\\' && !strings.HasPrefix(string(runes[idx:]), delim) {
+				buf.WriteRune('\\')
+			}
+			buf.WriteRune(runes[idx])
+		} else {
+			if runes[idx] == '\\' {
+				escape = true
+			} else if strings.HasPrefix(string(runes[idx:]), delim) {
+				idx += len(delim) - 1
+				vals = append(vals, strings.TrimSpace(buf.String()))
+				buf.Reset()
+			} else {
+				buf.WriteRune(runes[idx])
+			}
+		}
+		idx++
+		if idx == len(runes) {
+			break
+		}
+	}
+
+	if buf.Len() > 0 {
+		vals = append(vals, strings.TrimSpace(buf.String()))
+	}
+
+	return vals
+}
+
+// StringsWithShadows returns list of string divided by given delimiter.
+// Shadows will also be appended if any.
+func (k *Key) StringsWithShadows(delim string) []string {
+	vals := k.ValueWithShadows()
+	results := make([]string, 0, len(vals)*2)
+	for i := range vals {
+		if len(vals) == 0 {
+			continue
+		}
+
+		results = append(results, strings.Split(vals[i], delim)...)
+	}
+
+	for i := range results {
+		results[i] = k.transformValue(strings.TrimSpace(results[i]))
+	}
+	return results
+}
+
+// Float64s returns list of float64 divided by given delimiter. Any invalid input will be treated as zero value.
+func (k *Key) Float64s(delim string) []float64 {
+	vals, _ := k.parseFloat64s(k.Strings(delim), true, false)
+	return vals
+}
+
+// Ints returns list of int divided by given delimiter. Any invalid input will be treated as zero value.
+func (k *Key) Ints(delim string) []int {
+	vals, _ := k.parseInts(k.Strings(delim), true, false)
+	return vals
+}
+
+// Int64s returns list of int64 divided by given delimiter. Any invalid input will be treated as zero value.
+func (k *Key) Int64s(delim string) []int64 {
+	vals, _ := k.parseInt64s(k.Strings(delim), true, false)
+	return vals
+}
+
+// Uints returns list of uint divided by given delimiter. Any invalid input will be treated as zero value.
+func (k *Key) Uints(delim string) []uint {
+	vals, _ := k.parseUints(k.Strings(delim), true, false)
+	return vals
+}
+
+// Uint64s returns list of uint64 divided by given delimiter. Any invalid input will be treated as zero value.
+func (k *Key) Uint64s(delim string) []uint64 {
+	vals, _ := k.parseUint64s(k.Strings(delim), true, false)
+	return vals
+}
+
+// Bools returns list of bool divided by given delimiter. Any invalid input will be treated as zero value.
+func (k *Key) Bools(delim string) []bool {
+	vals, _ := k.parseBools(k.Strings(delim), true, false)
+	return vals
+}
+
+// TimesFormat parses with given format and returns list of time.Time divided by given delimiter.
+// Any invalid input will be treated as zero value (0001-01-01 00:00:00 +0000 UTC).
+func (k *Key) TimesFormat(format, delim string) []time.Time {
+	vals, _ := k.parseTimesFormat(format, k.Strings(delim), true, false)
+	return vals
+}
+
+// Times parses with RFC3339 format and returns list of time.Time divided by given delimiter.
+// Any invalid input will be treated as zero value (0001-01-01 00:00:00 +0000 UTC).
+func (k *Key) Times(delim string) []time.Time {
+	return k.TimesFormat(time.RFC3339, delim)
+}
+
+// ValidFloat64s returns list of float64 divided by given delimiter. If some value is not float, then
+// it will not be included to result list.
+func (k *Key) ValidFloat64s(delim string) []float64 {
+	vals, _ := k.parseFloat64s(k.Strings(delim), false, false)
+	return vals
+}
+
+// ValidInts returns list of int divided by given delimiter. If some value is not integer, then it will
+// not be included to result list.
+func (k *Key) ValidInts(delim string) []int {
+	vals, _ := k.parseInts(k.Strings(delim), false, false)
+	return vals
+}
+
+// ValidInt64s returns list of int64 divided by given delimiter. If some value is not 64-bit integer,
+// then it will not be included to result list.
+func (k *Key) ValidInt64s(delim string) []int64 {
+	vals, _ := k.parseInt64s(k.Strings(delim), false, false)
+	return vals
+}
+
+// ValidUints returns list of uint divided by given delimiter. If some value is not unsigned integer,
+// then it will not be included to result list.
+func (k *Key) ValidUints(delim string) []uint {
+	vals, _ := k.parseUints(k.Strings(delim), false, false)
+	return vals
+}
+
+// ValidUint64s returns list of uint64 divided by given delimiter. If some value is not 64-bit unsigned
+// integer, then it will not be included to result list.
+func (k *Key) ValidUint64s(delim string) []uint64 {
+	vals, _ := k.parseUint64s(k.Strings(delim), false, false)
+	return vals
+}
+
+// ValidBools returns list of bool divided by given delimiter. If some value is not 64-bit unsigned
+// integer, then it will not be included to result list.
+func (k *Key) ValidBools(delim string) []bool {
+	vals, _ := k.parseBools(k.Strings(delim), false, false)
+	return vals
+}
+
+// ValidTimesFormat parses with given format and returns list of time.Time divided by given delimiter.
+func (k *Key) ValidTimesFormat(format, delim string) []time.Time {
+	vals, _ := k.parseTimesFormat(format, k.Strings(delim), false, false)
+	return vals
+}
+
+// ValidTimes parses with RFC3339 format and returns list of time.Time divided by given delimiter.
+func (k *Key) ValidTimes(delim string) []time.Time {
+	return k.ValidTimesFormat(time.RFC3339, delim)
+}
+
+// StrictFloat64s returns list of float64 divided by given delimiter or error on first invalid input.
+func (k *Key) StrictFloat64s(delim string) ([]float64, error) {
+	return k.parseFloat64s(k.Strings(delim), false, true)
+}
+
+// StrictInts returns list of int divided by given delimiter or error on first invalid input.
+func (k *Key) StrictInts(delim string) ([]int, error) {
+	return k.parseInts(k.Strings(delim), false, true)
+}
+
+// StrictInt64s returns list of int64 divided by given delimiter or error on first invalid input.
+func (k *Key) StrictInt64s(delim string) ([]int64, error) {
+	return k.parseInt64s(k.Strings(delim), false, true)
+}
+
+// StrictUints returns list of uint divided by given delimiter or error on first invalid input.
+func (k *Key) StrictUints(delim string) ([]uint, error) {
+	return k.parseUints(k.Strings(delim), false, true)
+}
+
+// StrictUint64s returns list of uint64 divided by given delimiter or error on first invalid input.
+func (k *Key) StrictUint64s(delim string) ([]uint64, error) {
+	return k.parseUint64s(k.Strings(delim), false, true)
+}
+
+// StrictBools returns list of bool divided by given delimiter or error on first invalid input.
+func (k *Key) StrictBools(delim string) ([]bool, error) {
+	return k.parseBools(k.Strings(delim), false, true)
+}
+
+// StrictTimesFormat parses with given format and returns list of time.Time divided by given delimiter
+// or error on first invalid input.
+func (k *Key) StrictTimesFormat(format, delim string) ([]time.Time, error) {
+	return k.parseTimesFormat(format, k.Strings(delim), false, true)
+}
+
+// StrictTimes parses with RFC3339 format and returns list of time.Time divided by given delimiter
+// or error on first invalid input.
+func (k *Key) StrictTimes(delim string) ([]time.Time, error) {
+	return k.StrictTimesFormat(time.RFC3339, delim)
+}
+
+// parseBools transforms strings to bools.
+func (k *Key) parseBools(strs []string, addInvalid, returnOnInvalid bool) ([]bool, error) {
+	vals := make([]bool, 0, len(strs))
+	for _, str := range strs {
+		val, err := parseBool(str)
+		if err != nil && returnOnInvalid {
+			return nil, err
+		}
+		if err == nil || addInvalid {
+			vals = append(vals, val)
+		}
+	}
+	return vals, nil
+}
+
+// parseFloat64s transforms strings to float64s.
+func (k *Key) parseFloat64s(strs []string, addInvalid, returnOnInvalid bool) ([]float64, error) {
+	vals := make([]float64, 0, len(strs))
+	for _, str := range strs {
+		val, err := strconv.ParseFloat(str, 64)
+		if err != nil && returnOnInvalid {
+			return nil, err
+		}
+		if err == nil || addInvalid {
+			vals = append(vals, val)
+		}
+	}
+	return vals, nil
+}
+
+// parseInts transforms strings to ints.
+func (k *Key) parseInts(strs []string, addInvalid, returnOnInvalid bool) ([]int, error) {
+	vals := make([]int, 0, len(strs))
+	for _, str := range strs {
+		valInt64, err := strconv.ParseInt(str, 0, 64)
+		val := int(valInt64)
+		if err != nil && returnOnInvalid {
+			return nil, err
+		}
+		if err == nil || addInvalid {
+			vals = append(vals, val)
+		}
+	}
+	return vals, nil
+}
+
+// parseInt64s transforms strings to int64s.
+func (k *Key) parseInt64s(strs []string, addInvalid, returnOnInvalid bool) ([]int64, error) {
+	vals := make([]int64, 0, len(strs))
+	for _, str := range strs {
+		val, err := strconv.ParseInt(str, 0, 64)
+		if err != nil && returnOnInvalid {
+			return nil, err
+		}
+		if err == nil || addInvalid {
+			vals = append(vals, val)
+		}
+	}
+	return vals, nil
+}
+
+// parseUints transforms strings to uints.
+func (k *Key) parseUints(strs []string, addInvalid, returnOnInvalid bool) ([]uint, error) {
+	vals := make([]uint, 0, len(strs))
+	for _, str := range strs {
+		val, err := strconv.ParseUint(str, 0, 0)
+		if err != nil && returnOnInvalid {
+			return nil, err
+		}
+		if err == nil || addInvalid {
+			vals = append(vals, uint(val))
+		}
+	}
+	return vals, nil
+}
+
+// parseUint64s transforms strings to uint64s.
+func (k *Key) parseUint64s(strs []string, addInvalid, returnOnInvalid bool) ([]uint64, error) {
+	vals := make([]uint64, 0, len(strs))
+	for _, str := range strs {
+		val, err := strconv.ParseUint(str, 0, 64)
+		if err != nil && returnOnInvalid {
+			return nil, err
+		}
+		if err == nil || addInvalid {
+			vals = append(vals, val)
+		}
+	}
+	return vals, nil
+}
+
+// parseTimesFormat transforms strings to times in given format.
+func (k *Key) parseTimesFormat(format string, strs []string, addInvalid, returnOnInvalid bool) ([]time.Time, error) {
+	vals := make([]time.Time, 0, len(strs))
+	for _, str := range strs {
+		val, err := time.Parse(format, str)
+		if err != nil && returnOnInvalid {
+			return nil, err
+		}
+		if err == nil || addInvalid {
+			vals = append(vals, val)
+		}
+	}
+	return vals, nil
+}
+
+// SetValue changes key value.
+func (k *Key) SetValue(v string) {
+	if k.s.f.BlockMode {
+		k.s.f.lock.Lock()
+		defer k.s.f.lock.Unlock()
+	}
+
+	k.value = v
+	k.s.keysHash[k.name] = v
+}

--- a/vendor/gopkg.in/ini.v1/parser.go
+++ b/vendor/gopkg.in/ini.v1/parser.go
@@ -1,0 +1,526 @@
+// Copyright 2015 Unknwon
+//
+// Licensed under the Apache License, Version 2.0 (the "License"): you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package ini
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+const minReaderBufferSize = 4096
+
+var pythonMultiline = regexp.MustCompile(`^([\t\f ]+)(.*)`)
+
+type parserOptions struct {
+	IgnoreContinuation          bool
+	IgnoreInlineComment         bool
+	AllowPythonMultilineValues  bool
+	SpaceBeforeInlineComment    bool
+	UnescapeValueDoubleQuotes   bool
+	UnescapeValueCommentSymbols bool
+	PreserveSurroundedQuote     bool
+	DebugFunc                   DebugFunc
+	ReaderBufferSize            int
+}
+
+type parser struct {
+	buf     *bufio.Reader
+	options parserOptions
+
+	isEOF   bool
+	count   int
+	comment *bytes.Buffer
+}
+
+func (p *parser) debug(format string, args ...interface{}) {
+	if p.options.DebugFunc != nil {
+		p.options.DebugFunc(fmt.Sprintf(format, args...))
+	}
+}
+
+func newParser(r io.Reader, opts parserOptions) *parser {
+	size := opts.ReaderBufferSize
+	if size < minReaderBufferSize {
+		size = minReaderBufferSize
+	}
+
+	return &parser{
+		buf:     bufio.NewReaderSize(r, size),
+		options: opts,
+		count:   1,
+		comment: &bytes.Buffer{},
+	}
+}
+
+// BOM handles header of UTF-8, UTF-16 LE and UTF-16 BE's BOM format.
+// http://en.wikipedia.org/wiki/Byte_order_mark#Representations_of_byte_order_marks_by_encoding
+func (p *parser) BOM() error {
+	mask, err := p.buf.Peek(2)
+	if err != nil && err != io.EOF {
+		return err
+	} else if len(mask) < 2 {
+		return nil
+	}
+
+	switch {
+	case mask[0] == 254 && mask[1] == 255:
+		fallthrough
+	case mask[0] == 255 && mask[1] == 254:
+		p.buf.Read(mask)
+	case mask[0] == 239 && mask[1] == 187:
+		mask, err := p.buf.Peek(3)
+		if err != nil && err != io.EOF {
+			return err
+		} else if len(mask) < 3 {
+			return nil
+		}
+		if mask[2] == 191 {
+			p.buf.Read(mask)
+		}
+	}
+	return nil
+}
+
+func (p *parser) readUntil(delim byte) ([]byte, error) {
+	data, err := p.buf.ReadBytes(delim)
+	if err != nil {
+		if err == io.EOF {
+			p.isEOF = true
+		} else {
+			return nil, err
+		}
+	}
+	return data, nil
+}
+
+func cleanComment(in []byte) ([]byte, bool) {
+	i := bytes.IndexAny(in, "#;")
+	if i == -1 {
+		return nil, false
+	}
+	return in[i:], true
+}
+
+func readKeyName(delimiters string, in []byte) (string, int, error) {
+	line := string(in)
+
+	// Check if key name surrounded by quotes.
+	var keyQuote string
+	if line[0] == '"' {
+		if len(line) > 6 && string(line[0:3]) == `"""` {
+			keyQuote = `"""`
+		} else {
+			keyQuote = `"`
+		}
+	} else if line[0] == '`' {
+		keyQuote = "`"
+	}
+
+	// Get out key name
+	endIdx := -1
+	if len(keyQuote) > 0 {
+		startIdx := len(keyQuote)
+		// FIXME: fail case -> """"""name"""=value
+		pos := strings.Index(line[startIdx:], keyQuote)
+		if pos == -1 {
+			return "", -1, fmt.Errorf("missing closing key quote: %s", line)
+		}
+		pos += startIdx
+
+		// Find key-value delimiter
+		i := strings.IndexAny(line[pos+startIdx:], delimiters)
+		if i < 0 {
+			return "", -1, ErrDelimiterNotFound{line}
+		}
+		endIdx = pos + i
+		return strings.TrimSpace(line[startIdx:pos]), endIdx + startIdx + 1, nil
+	}
+
+	endIdx = strings.IndexAny(line, delimiters)
+	if endIdx < 0 {
+		return "", -1, ErrDelimiterNotFound{line}
+	}
+	return strings.TrimSpace(line[0:endIdx]), endIdx + 1, nil
+}
+
+func (p *parser) readMultilines(line, val, valQuote string) (string, error) {
+	for {
+		data, err := p.readUntil('\n')
+		if err != nil {
+			return "", err
+		}
+		next := string(data)
+
+		pos := strings.LastIndex(next, valQuote)
+		if pos > -1 {
+			val += next[:pos]
+
+			comment, has := cleanComment([]byte(next[pos:]))
+			if has {
+				p.comment.Write(bytes.TrimSpace(comment))
+			}
+			break
+		}
+		val += next
+		if p.isEOF {
+			return "", fmt.Errorf("missing closing key quote from '%s' to '%s'", line, next)
+		}
+	}
+	return val, nil
+}
+
+func (p *parser) readContinuationLines(val string) (string, error) {
+	for {
+		data, err := p.readUntil('\n')
+		if err != nil {
+			return "", err
+		}
+		next := strings.TrimSpace(string(data))
+
+		if len(next) == 0 {
+			break
+		}
+		val += next
+		if val[len(val)-1] != '\\' {
+			break
+		}
+		val = val[:len(val)-1]
+	}
+	return val, nil
+}
+
+// hasSurroundedQuote check if and only if the first and last characters
+// are quotes \" or \'.
+// It returns false if any other parts also contain same kind of quotes.
+func hasSurroundedQuote(in string, quote byte) bool {
+	return len(in) >= 2 && in[0] == quote && in[len(in)-1] == quote &&
+		strings.IndexByte(in[1:], quote) == len(in)-2
+}
+
+func (p *parser) readValue(in []byte, bufferSize int) (string, error) {
+
+	line := strings.TrimLeftFunc(string(in), unicode.IsSpace)
+	if len(line) == 0 {
+		if p.options.AllowPythonMultilineValues && len(in) > 0 && in[len(in)-1] == '\n' {
+			return p.readPythonMultilines(line, bufferSize)
+		}
+		return "", nil
+	}
+
+	var valQuote string
+	if len(line) > 3 && string(line[0:3]) == `"""` {
+		valQuote = `"""`
+	} else if line[0] == '`' {
+		valQuote = "`"
+	} else if p.options.UnescapeValueDoubleQuotes && line[0] == '"' {
+		valQuote = `"`
+	}
+
+	if len(valQuote) > 0 {
+		startIdx := len(valQuote)
+		pos := strings.LastIndex(line[startIdx:], valQuote)
+		// Check for multi-line value
+		if pos == -1 {
+			return p.readMultilines(line, line[startIdx:], valQuote)
+		}
+
+		if p.options.UnescapeValueDoubleQuotes && valQuote == `"` {
+			return strings.Replace(line[startIdx:pos+startIdx], `\"`, `"`, -1), nil
+		}
+		return line[startIdx : pos+startIdx], nil
+	}
+
+	lastChar := line[len(line)-1]
+	// Won't be able to reach here if value only contains whitespace
+	line = strings.TrimSpace(line)
+	trimmedLastChar := line[len(line)-1]
+
+	// Check continuation lines when desired
+	if !p.options.IgnoreContinuation && trimmedLastChar == '\\' {
+		return p.readContinuationLines(line[:len(line)-1])
+	}
+
+	// Check if ignore inline comment
+	if !p.options.IgnoreInlineComment {
+		var i int
+		if p.options.SpaceBeforeInlineComment {
+			i = strings.Index(line, " #")
+			if i == -1 {
+				i = strings.Index(line, " ;")
+			}
+
+		} else {
+			i = strings.IndexAny(line, "#;")
+		}
+
+		if i > -1 {
+			p.comment.WriteString(line[i:])
+			line = strings.TrimSpace(line[:i])
+		}
+
+	}
+
+	// Trim single and double quotes
+	if (hasSurroundedQuote(line, '\'') ||
+		hasSurroundedQuote(line, '"')) && !p.options.PreserveSurroundedQuote {
+		line = line[1 : len(line)-1]
+	} else if len(valQuote) == 0 && p.options.UnescapeValueCommentSymbols {
+		if strings.Contains(line, `\;`) {
+			line = strings.Replace(line, `\;`, ";", -1)
+		}
+		if strings.Contains(line, `\#`) {
+			line = strings.Replace(line, `\#`, "#", -1)
+		}
+	} else if p.options.AllowPythonMultilineValues && lastChar == '\n' {
+		return p.readPythonMultilines(line, bufferSize)
+	}
+
+	return line, nil
+}
+
+func (p *parser) readPythonMultilines(line string, bufferSize int) (string, error) {
+	parserBufferPeekResult, _ := p.buf.Peek(bufferSize)
+	peekBuffer := bytes.NewBuffer(parserBufferPeekResult)
+
+	indentSize := 0
+	for {
+		peekData, peekErr := peekBuffer.ReadBytes('\n')
+		if peekErr != nil {
+			if peekErr == io.EOF {
+				p.debug("readPythonMultilines: io.EOF, peekData: %q, line: %q", string(peekData), line)
+				return line, nil
+			}
+
+			p.debug("readPythonMultilines: failed to peek with error: %v", peekErr)
+			return "", peekErr
+		}
+
+		p.debug("readPythonMultilines: parsing %q", string(peekData))
+
+		peekMatches := pythonMultiline.FindStringSubmatch(string(peekData))
+		p.debug("readPythonMultilines: matched %d parts", len(peekMatches))
+		for n, v := range peekMatches {
+			p.debug("   %d: %q", n, v)
+		}
+
+		// Return if not a Python multiline value.
+		if len(peekMatches) != 3 {
+			p.debug("readPythonMultilines: end of value, got: %q", line)
+			return line, nil
+		}
+
+		// Determine indent size and line prefix.
+		currentIndentSize := len(peekMatches[1])
+		if indentSize < 1 {
+			indentSize = currentIndentSize
+			p.debug("readPythonMultilines: indent size is %d", indentSize)
+		}
+
+		// Make sure each line is indented at least as far as first line.
+		if currentIndentSize < indentSize {
+			p.debug("readPythonMultilines: end of value, current indent: %d, expected indent: %d, line: %q", currentIndentSize, indentSize, line)
+			return line, nil
+		}
+
+		// Advance the parser reader (buffer) in-sync with the peek buffer.
+		_, err := p.buf.Discard(len(peekData))
+		if err != nil {
+			p.debug("readPythonMultilines: failed to skip to the end, returning error")
+			return "", err
+		}
+
+		// Handle indented empty line.
+		line += "\n" + peekMatches[1][indentSize:] + peekMatches[2]
+	}
+}
+
+// parse parses data through an io.Reader.
+func (f *File) parse(reader io.Reader) (err error) {
+	p := newParser(reader, parserOptions{
+		IgnoreContinuation:          f.options.IgnoreContinuation,
+		IgnoreInlineComment:         f.options.IgnoreInlineComment,
+		AllowPythonMultilineValues:  f.options.AllowPythonMultilineValues,
+		SpaceBeforeInlineComment:    f.options.SpaceBeforeInlineComment,
+		UnescapeValueDoubleQuotes:   f.options.UnescapeValueDoubleQuotes,
+		UnescapeValueCommentSymbols: f.options.UnescapeValueCommentSymbols,
+		PreserveSurroundedQuote:     f.options.PreserveSurroundedQuote,
+		DebugFunc:                   f.options.DebugFunc,
+		ReaderBufferSize:            f.options.ReaderBufferSize,
+	})
+	if err = p.BOM(); err != nil {
+		return fmt.Errorf("BOM: %v", err)
+	}
+
+	// Ignore error because default section name is never empty string.
+	name := DefaultSection
+	if f.options.Insensitive {
+		name = strings.ToLower(DefaultSection)
+	}
+	section, _ := f.NewSection(name)
+
+	// This "last" is not strictly equivalent to "previous one" if current key is not the first nested key
+	var isLastValueEmpty bool
+	var lastRegularKey *Key
+
+	var line []byte
+	var inUnparseableSection bool
+
+	// NOTE: Iterate and increase `currentPeekSize` until
+	// the size of the parser buffer is found.
+	// TODO(unknwon): When Golang 1.10 is the lowest version supported, replace with `parserBufferSize := p.buf.Size()`.
+	parserBufferSize := 0
+	// NOTE: Peek 4kb at a time.
+	currentPeekSize := minReaderBufferSize
+
+	if f.options.AllowPythonMultilineValues {
+		for {
+			peekBytes, _ := p.buf.Peek(currentPeekSize)
+			peekBytesLength := len(peekBytes)
+
+			if parserBufferSize >= peekBytesLength {
+				break
+			}
+
+			currentPeekSize *= 2
+			parserBufferSize = peekBytesLength
+		}
+	}
+
+	for !p.isEOF {
+		line, err = p.readUntil('\n')
+		if err != nil {
+			return err
+		}
+
+		if f.options.AllowNestedValues &&
+			isLastValueEmpty && len(line) > 0 {
+			if line[0] == ' ' || line[0] == '\t' {
+				lastRegularKey.addNestedValue(string(bytes.TrimSpace(line)))
+				continue
+			}
+		}
+
+		line = bytes.TrimLeftFunc(line, unicode.IsSpace)
+		if len(line) == 0 {
+			continue
+		}
+
+		// Comments
+		if line[0] == '#' || line[0] == ';' {
+			// Note: we do not care ending line break,
+			// it is needed for adding second line,
+			// so just clean it once at the end when set to value.
+			p.comment.Write(line)
+			continue
+		}
+
+		// Section
+		if line[0] == '[' {
+			// Read to the next ']' (TODO: support quoted strings)
+			closeIdx := bytes.LastIndexByte(line, ']')
+			if closeIdx == -1 {
+				return fmt.Errorf("unclosed section: %s", line)
+			}
+
+			name := string(line[1:closeIdx])
+			section, err = f.NewSection(name)
+			if err != nil {
+				return err
+			}
+
+			comment, has := cleanComment(line[closeIdx+1:])
+			if has {
+				p.comment.Write(comment)
+			}
+
+			section.Comment = strings.TrimSpace(p.comment.String())
+
+			// Reset auto-counter and comments
+			p.comment.Reset()
+			p.count = 1
+
+			inUnparseableSection = false
+			for i := range f.options.UnparseableSections {
+				if f.options.UnparseableSections[i] == name ||
+					(f.options.Insensitive && strings.ToLower(f.options.UnparseableSections[i]) == strings.ToLower(name)) {
+					inUnparseableSection = true
+					continue
+				}
+			}
+			continue
+		}
+
+		if inUnparseableSection {
+			section.isRawSection = true
+			section.rawBody += string(line)
+			continue
+		}
+
+		kname, offset, err := readKeyName(f.options.KeyValueDelimiters, line)
+		if err != nil {
+			// Treat as boolean key when desired, and whole line is key name.
+			if IsErrDelimiterNotFound(err) {
+				switch {
+				case f.options.AllowBooleanKeys:
+					kname, err := p.readValue(line, parserBufferSize)
+					if err != nil {
+						return err
+					}
+					key, err := section.NewBooleanKey(kname)
+					if err != nil {
+						return err
+					}
+					key.Comment = strings.TrimSpace(p.comment.String())
+					p.comment.Reset()
+					continue
+
+				case f.options.SkipUnrecognizableLines:
+					continue
+				}
+			}
+			return err
+		}
+
+		// Auto increment.
+		isAutoIncr := false
+		if kname == "-" {
+			isAutoIncr = true
+			kname = "#" + strconv.Itoa(p.count)
+			p.count++
+		}
+
+		value, err := p.readValue(line[offset:], parserBufferSize)
+		if err != nil {
+			return err
+		}
+		isLastValueEmpty = len(value) == 0
+
+		key, err := section.NewKey(kname, value)
+		if err != nil {
+			return err
+		}
+		key.isAutoIncrement = isAutoIncr
+		key.Comment = strings.TrimSpace(p.comment.String())
+		p.comment.Reset()
+		lastRegularKey = key
+	}
+	return nil
+}

--- a/vendor/gopkg.in/ini.v1/section.go
+++ b/vendor/gopkg.in/ini.v1/section.go
@@ -1,0 +1,256 @@
+// Copyright 2014 Unknwon
+//
+// Licensed under the Apache License, Version 2.0 (the "License"): you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package ini
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Section represents a config section.
+type Section struct {
+	f        *File
+	Comment  string
+	name     string
+	keys     map[string]*Key
+	keyList  []string
+	keysHash map[string]string
+
+	isRawSection bool
+	rawBody      string
+}
+
+func newSection(f *File, name string) *Section {
+	return &Section{
+		f:        f,
+		name:     name,
+		keys:     make(map[string]*Key),
+		keyList:  make([]string, 0, 10),
+		keysHash: make(map[string]string),
+	}
+}
+
+// Name returns name of Section.
+func (s *Section) Name() string {
+	return s.name
+}
+
+// Body returns rawBody of Section if the section was marked as unparseable.
+// It still follows the other rules of the INI format surrounding leading/trailing whitespace.
+func (s *Section) Body() string {
+	return strings.TrimSpace(s.rawBody)
+}
+
+// SetBody updates body content only if section is raw.
+func (s *Section) SetBody(body string) {
+	if !s.isRawSection {
+		return
+	}
+	s.rawBody = body
+}
+
+// NewKey creates a new key to given section.
+func (s *Section) NewKey(name, val string) (*Key, error) {
+	if len(name) == 0 {
+		return nil, errors.New("error creating new key: empty key name")
+	} else if s.f.options.Insensitive {
+		name = strings.ToLower(name)
+	}
+
+	if s.f.BlockMode {
+		s.f.lock.Lock()
+		defer s.f.lock.Unlock()
+	}
+
+	if inSlice(name, s.keyList) {
+		if s.f.options.AllowShadows {
+			if err := s.keys[name].addShadow(val); err != nil {
+				return nil, err
+			}
+		} else {
+			s.keys[name].value = val
+			s.keysHash[name] = val
+		}
+		return s.keys[name], nil
+	}
+
+	s.keyList = append(s.keyList, name)
+	s.keys[name] = newKey(s, name, val)
+	s.keysHash[name] = val
+	return s.keys[name], nil
+}
+
+// NewBooleanKey creates a new boolean type key to given section.
+func (s *Section) NewBooleanKey(name string) (*Key, error) {
+	key, err := s.NewKey(name, "true")
+	if err != nil {
+		return nil, err
+	}
+
+	key.isBooleanType = true
+	return key, nil
+}
+
+// GetKey returns key in section by given name.
+func (s *Section) GetKey(name string) (*Key, error) {
+	if s.f.BlockMode {
+		s.f.lock.RLock()
+	}
+	if s.f.options.Insensitive {
+		name = strings.ToLower(name)
+	}
+	key := s.keys[name]
+	if s.f.BlockMode {
+		s.f.lock.RUnlock()
+	}
+
+	if key == nil {
+		// Check if it is a child-section.
+		sname := s.name
+		for {
+			if i := strings.LastIndex(sname, "."); i > -1 {
+				sname = sname[:i]
+				sec, err := s.f.GetSection(sname)
+				if err != nil {
+					continue
+				}
+				return sec.GetKey(name)
+			}
+			break
+		}
+		return nil, fmt.Errorf("error when getting key of section '%s': key '%s' not exists", s.name, name)
+	}
+	return key, nil
+}
+
+// HasKey returns true if section contains a key with given name.
+func (s *Section) HasKey(name string) bool {
+	key, _ := s.GetKey(name)
+	return key != nil
+}
+
+// Deprecated: Use "HasKey" instead.
+func (s *Section) Haskey(name string) bool {
+	return s.HasKey(name)
+}
+
+// HasValue returns true if section contains given raw value.
+func (s *Section) HasValue(value string) bool {
+	if s.f.BlockMode {
+		s.f.lock.RLock()
+		defer s.f.lock.RUnlock()
+	}
+
+	for _, k := range s.keys {
+		if value == k.value {
+			return true
+		}
+	}
+	return false
+}
+
+// Key assumes named Key exists in section and returns a zero-value when not.
+func (s *Section) Key(name string) *Key {
+	key, err := s.GetKey(name)
+	if err != nil {
+		// It's OK here because the only possible error is empty key name,
+		// but if it's empty, this piece of code won't be executed.
+		key, _ = s.NewKey(name, "")
+		return key
+	}
+	return key
+}
+
+// Keys returns list of keys of section.
+func (s *Section) Keys() []*Key {
+	keys := make([]*Key, len(s.keyList))
+	for i := range s.keyList {
+		keys[i] = s.Key(s.keyList[i])
+	}
+	return keys
+}
+
+// ParentKeys returns list of keys of parent section.
+func (s *Section) ParentKeys() []*Key {
+	var parentKeys []*Key
+	sname := s.name
+	for {
+		if i := strings.LastIndex(sname, "."); i > -1 {
+			sname = sname[:i]
+			sec, err := s.f.GetSection(sname)
+			if err != nil {
+				continue
+			}
+			parentKeys = append(parentKeys, sec.Keys()...)
+		} else {
+			break
+		}
+
+	}
+	return parentKeys
+}
+
+// KeyStrings returns list of key names of section.
+func (s *Section) KeyStrings() []string {
+	list := make([]string, len(s.keyList))
+	copy(list, s.keyList)
+	return list
+}
+
+// KeysHash returns keys hash consisting of names and values.
+func (s *Section) KeysHash() map[string]string {
+	if s.f.BlockMode {
+		s.f.lock.RLock()
+		defer s.f.lock.RUnlock()
+	}
+
+	hash := map[string]string{}
+	for key, value := range s.keysHash {
+		hash[key] = value
+	}
+	return hash
+}
+
+// DeleteKey deletes a key from section.
+func (s *Section) DeleteKey(name string) {
+	if s.f.BlockMode {
+		s.f.lock.Lock()
+		defer s.f.lock.Unlock()
+	}
+
+	for i, k := range s.keyList {
+		if k == name {
+			s.keyList = append(s.keyList[:i], s.keyList[i+1:]...)
+			delete(s.keys, name)
+			delete(s.keysHash, name)
+			return
+		}
+	}
+}
+
+// ChildSections returns a list of child sections of current section.
+// For example, "[parent.child1]" and "[parent.child12]" are child sections
+// of section "[parent]".
+func (s *Section) ChildSections() []*Section {
+	prefix := s.name + "."
+	children := make([]*Section, 0, 3)
+	for _, name := range s.f.sectionList {
+		if strings.HasPrefix(name, prefix) {
+			children = append(children, s.f.sections[name])
+		}
+	}
+	return children
+}

--- a/vendor/gopkg.in/ini.v1/struct.go
+++ b/vendor/gopkg.in/ini.v1/struct.go
@@ -1,0 +1,615 @@
+// Copyright 2014 Unknwon
+//
+// Licensed under the Apache License, Version 2.0 (the "License"): you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package ini
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+	"unicode"
+)
+
+// NameMapper represents a ini tag name mapper.
+type NameMapper func(string) string
+
+// Built-in name getters.
+var (
+	// SnackCase converts to format SNACK_CASE.
+	SnackCase NameMapper = func(raw string) string {
+		newstr := make([]rune, 0, len(raw))
+		for i, chr := range raw {
+			if isUpper := 'A' <= chr && chr <= 'Z'; isUpper {
+				if i > 0 {
+					newstr = append(newstr, '_')
+				}
+			}
+			newstr = append(newstr, unicode.ToUpper(chr))
+		}
+		return string(newstr)
+	}
+	// TitleUnderscore converts to format title_underscore.
+	TitleUnderscore NameMapper = func(raw string) string {
+		newstr := make([]rune, 0, len(raw))
+		for i, chr := range raw {
+			if isUpper := 'A' <= chr && chr <= 'Z'; isUpper {
+				if i > 0 {
+					newstr = append(newstr, '_')
+				}
+				chr -= 'A' - 'a'
+			}
+			newstr = append(newstr, chr)
+		}
+		return string(newstr)
+	}
+)
+
+func (s *Section) parseFieldName(raw, actual string) string {
+	if len(actual) > 0 {
+		return actual
+	}
+	if s.f.NameMapper != nil {
+		return s.f.NameMapper(raw)
+	}
+	return raw
+}
+
+func parseDelim(actual string) string {
+	if len(actual) > 0 {
+		return actual
+	}
+	return ","
+}
+
+var reflectTime = reflect.TypeOf(time.Now()).Kind()
+
+// setSliceWithProperType sets proper values to slice based on its type.
+func setSliceWithProperType(key *Key, field reflect.Value, delim string, allowShadow, isStrict bool) error {
+	var strs []string
+	if allowShadow {
+		strs = key.StringsWithShadows(delim)
+	} else {
+		strs = key.Strings(delim)
+	}
+
+	numVals := len(strs)
+	if numVals == 0 {
+		return nil
+	}
+
+	var vals interface{}
+	var err error
+
+	sliceOf := field.Type().Elem().Kind()
+	switch sliceOf {
+	case reflect.String:
+		vals = strs
+	case reflect.Int:
+		vals, err = key.parseInts(strs, true, false)
+	case reflect.Int64:
+		vals, err = key.parseInt64s(strs, true, false)
+	case reflect.Uint:
+		vals, err = key.parseUints(strs, true, false)
+	case reflect.Uint64:
+		vals, err = key.parseUint64s(strs, true, false)
+	case reflect.Float64:
+		vals, err = key.parseFloat64s(strs, true, false)
+	case reflect.Bool:
+		vals, err = key.parseBools(strs, true, false)
+	case reflectTime:
+		vals, err = key.parseTimesFormat(time.RFC3339, strs, true, false)
+	default:
+		return fmt.Errorf("unsupported type '[]%s'", sliceOf)
+	}
+	if err != nil && isStrict {
+		return err
+	}
+
+	slice := reflect.MakeSlice(field.Type(), numVals, numVals)
+	for i := 0; i < numVals; i++ {
+		switch sliceOf {
+		case reflect.String:
+			slice.Index(i).Set(reflect.ValueOf(vals.([]string)[i]))
+		case reflect.Int:
+			slice.Index(i).Set(reflect.ValueOf(vals.([]int)[i]))
+		case reflect.Int64:
+			slice.Index(i).Set(reflect.ValueOf(vals.([]int64)[i]))
+		case reflect.Uint:
+			slice.Index(i).Set(reflect.ValueOf(vals.([]uint)[i]))
+		case reflect.Uint64:
+			slice.Index(i).Set(reflect.ValueOf(vals.([]uint64)[i]))
+		case reflect.Float64:
+			slice.Index(i).Set(reflect.ValueOf(vals.([]float64)[i]))
+		case reflect.Bool:
+			slice.Index(i).Set(reflect.ValueOf(vals.([]bool)[i]))
+		case reflectTime:
+			slice.Index(i).Set(reflect.ValueOf(vals.([]time.Time)[i]))
+		}
+	}
+	field.Set(slice)
+	return nil
+}
+
+func wrapStrictError(err error, isStrict bool) error {
+	if isStrict {
+		return err
+	}
+	return nil
+}
+
+// setWithProperType sets proper value to field based on its type,
+// but it does not return error for failing parsing,
+// because we want to use default value that is already assigned to struct.
+func setWithProperType(t reflect.Type, key *Key, field reflect.Value, delim string, allowShadow, isStrict bool) error {
+	vt := t
+	isPtr := t.Kind() == reflect.Ptr
+	if isPtr {
+		vt = t.Elem()
+	}
+	switch vt.Kind() {
+	case reflect.String:
+		stringVal := key.String()
+		if isPtr {
+			field.Set(reflect.ValueOf(&stringVal))
+		} else if len(stringVal) > 0 {
+			field.SetString(key.String())
+		}
+	case reflect.Bool:
+		boolVal, err := key.Bool()
+		if err != nil {
+			return wrapStrictError(err, isStrict)
+		}
+		if isPtr {
+			field.Set(reflect.ValueOf(&boolVal))
+		} else {
+			field.SetBool(boolVal)
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		// ParseDuration will not return err for `0`, so check the type name
+		if vt.Name() == "Duration" {
+			durationVal, err := key.Duration()
+			if err != nil {
+				if intVal, err := key.Int64(); err == nil {
+					field.SetInt(intVal)
+					return nil
+				}
+				return wrapStrictError(err, isStrict)
+			}
+			if isPtr {
+				field.Set(reflect.ValueOf(&durationVal))
+			} else if int64(durationVal) > 0 {
+				field.Set(reflect.ValueOf(durationVal))
+			}
+			return nil
+		}
+
+		intVal, err := key.Int64()
+		if err != nil {
+			return wrapStrictError(err, isStrict)
+		}
+		if isPtr {
+			pv := reflect.New(t.Elem())
+			pv.Elem().SetInt(intVal)
+			field.Set(pv)
+		} else {
+			field.SetInt(intVal)
+		}
+	//	byte is an alias for uint8, so supporting uint8 breaks support for byte
+	case reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		durationVal, err := key.Duration()
+		// Skip zero value
+		if err == nil && uint64(durationVal) > 0 {
+			if isPtr {
+				field.Set(reflect.ValueOf(&durationVal))
+			} else {
+				field.Set(reflect.ValueOf(durationVal))
+			}
+			return nil
+		}
+
+		uintVal, err := key.Uint64()
+		if err != nil {
+			return wrapStrictError(err, isStrict)
+		}
+		if isPtr {
+			pv := reflect.New(t.Elem())
+			pv.Elem().SetUint(uintVal)
+			field.Set(pv)
+		} else {
+			field.SetUint(uintVal)
+		}
+
+	case reflect.Float32, reflect.Float64:
+		floatVal, err := key.Float64()
+		if err != nil {
+			return wrapStrictError(err, isStrict)
+		}
+		if isPtr {
+			pv := reflect.New(t.Elem())
+			pv.Elem().SetFloat(floatVal)
+			field.Set(pv)
+		} else {
+			field.SetFloat(floatVal)
+		}
+	case reflectTime:
+		timeVal, err := key.Time()
+		if err != nil {
+			return wrapStrictError(err, isStrict)
+		}
+		if isPtr {
+			field.Set(reflect.ValueOf(&timeVal))
+		} else {
+			field.Set(reflect.ValueOf(timeVal))
+		}
+	case reflect.Slice:
+		return setSliceWithProperType(key, field, delim, allowShadow, isStrict)
+	default:
+		return fmt.Errorf("unsupported type '%s'", t)
+	}
+	return nil
+}
+
+func parseTagOptions(tag string) (rawName string, omitEmpty bool, allowShadow bool) {
+	opts := strings.SplitN(tag, ",", 3)
+	rawName = opts[0]
+	if len(opts) > 1 {
+		omitEmpty = opts[1] == "omitempty"
+	}
+	if len(opts) > 2 {
+		allowShadow = opts[2] == "allowshadow"
+	}
+	return rawName, omitEmpty, allowShadow
+}
+
+func (s *Section) mapTo(val reflect.Value, isStrict bool) error {
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+	typ := val.Type()
+
+	for i := 0; i < typ.NumField(); i++ {
+		field := val.Field(i)
+		tpField := typ.Field(i)
+
+		tag := tpField.Tag.Get("ini")
+		if tag == "-" {
+			continue
+		}
+
+		rawName, _, allowShadow := parseTagOptions(tag)
+		fieldName := s.parseFieldName(tpField.Name, rawName)
+		if len(fieldName) == 0 || !field.CanSet() {
+			continue
+		}
+
+		isStruct := tpField.Type.Kind() == reflect.Struct
+		isStructPtr := tpField.Type.Kind() == reflect.Ptr && tpField.Type.Elem().Kind() == reflect.Struct
+		isAnonymous := tpField.Type.Kind() == reflect.Ptr && tpField.Anonymous
+		if isAnonymous {
+			field.Set(reflect.New(tpField.Type.Elem()))
+		}
+
+		if isAnonymous || isStruct || isStructPtr {
+			if sec, err := s.f.GetSection(fieldName); err == nil {
+				// Only set the field to non-nil struct value if we have a section for it.
+				// Otherwise, we end up with a non-nil struct ptr even though there is no data.
+				if isStructPtr && field.IsNil() {
+					field.Set(reflect.New(tpField.Type.Elem()))
+				}
+				if err = sec.mapTo(field, isStrict); err != nil {
+					return fmt.Errorf("error mapping field %q: %v", fieldName, err)
+				}
+				continue
+			}
+		}
+		if key, err := s.GetKey(fieldName); err == nil {
+			delim := parseDelim(tpField.Tag.Get("delim"))
+			if err = setWithProperType(tpField.Type, key, field, delim, allowShadow, isStrict); err != nil {
+				return fmt.Errorf("error mapping field %q: %v", fieldName, err)
+			}
+		}
+	}
+	return nil
+}
+
+// MapTo maps section to given struct.
+func (s *Section) MapTo(v interface{}) error {
+	typ := reflect.TypeOf(v)
+	val := reflect.ValueOf(v)
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+		val = val.Elem()
+	} else {
+		return errors.New("cannot map to non-pointer struct")
+	}
+
+	return s.mapTo(val, false)
+}
+
+// StrictMapTo maps section to given struct in strict mode,
+// which returns all possible error including value parsing error.
+func (s *Section) StrictMapTo(v interface{}) error {
+	typ := reflect.TypeOf(v)
+	val := reflect.ValueOf(v)
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+		val = val.Elem()
+	} else {
+		return errors.New("cannot map to non-pointer struct")
+	}
+
+	return s.mapTo(val, true)
+}
+
+// MapTo maps file to given struct.
+func (f *File) MapTo(v interface{}) error {
+	return f.Section("").MapTo(v)
+}
+
+// StrictMapTo maps file to given struct in strict mode,
+// which returns all possible error including value parsing error.
+func (f *File) StrictMapTo(v interface{}) error {
+	return f.Section("").StrictMapTo(v)
+}
+
+// MapToWithMapper maps data sources to given struct with name mapper.
+func MapToWithMapper(v interface{}, mapper NameMapper, source interface{}, others ...interface{}) error {
+	cfg, err := Load(source, others...)
+	if err != nil {
+		return err
+	}
+	cfg.NameMapper = mapper
+	return cfg.MapTo(v)
+}
+
+// StrictMapToWithMapper maps data sources to given struct with name mapper in strict mode,
+// which returns all possible error including value parsing error.
+func StrictMapToWithMapper(v interface{}, mapper NameMapper, source interface{}, others ...interface{}) error {
+	cfg, err := Load(source, others...)
+	if err != nil {
+		return err
+	}
+	cfg.NameMapper = mapper
+	return cfg.StrictMapTo(v)
+}
+
+// MapTo maps data sources to given struct.
+func MapTo(v, source interface{}, others ...interface{}) error {
+	return MapToWithMapper(v, nil, source, others...)
+}
+
+// StrictMapTo maps data sources to given struct in strict mode,
+// which returns all possible error including value parsing error.
+func StrictMapTo(v, source interface{}, others ...interface{}) error {
+	return StrictMapToWithMapper(v, nil, source, others...)
+}
+
+// reflectSliceWithProperType does the opposite thing as setSliceWithProperType.
+func reflectSliceWithProperType(key *Key, field reflect.Value, delim string, allowShadow bool) error {
+	slice := field.Slice(0, field.Len())
+	if field.Len() == 0 {
+		return nil
+	}
+	sliceOf := field.Type().Elem().Kind()
+
+	if allowShadow {
+		var keyWithShadows *Key
+		for i := 0; i < field.Len(); i++ {
+			var val string
+			switch sliceOf {
+			case reflect.String:
+				val = slice.Index(i).String()
+			case reflect.Int, reflect.Int64:
+				val = fmt.Sprint(slice.Index(i).Int())
+			case reflect.Uint, reflect.Uint64:
+				val = fmt.Sprint(slice.Index(i).Uint())
+			case reflect.Float64:
+				val = fmt.Sprint(slice.Index(i).Float())
+			case reflect.Bool:
+				val = fmt.Sprint(slice.Index(i).Bool())
+			case reflectTime:
+				val = slice.Index(i).Interface().(time.Time).Format(time.RFC3339)
+			default:
+				return fmt.Errorf("unsupported type '[]%s'", sliceOf)
+			}
+
+			if i == 0 {
+				keyWithShadows = newKey(key.s, key.name, val)
+			} else {
+				keyWithShadows.AddShadow(val)
+			}
+		}
+		key = keyWithShadows
+		return nil
+	}
+
+	var buf bytes.Buffer
+	for i := 0; i < field.Len(); i++ {
+		switch sliceOf {
+		case reflect.String:
+			buf.WriteString(slice.Index(i).String())
+		case reflect.Int, reflect.Int64:
+			buf.WriteString(fmt.Sprint(slice.Index(i).Int()))
+		case reflect.Uint, reflect.Uint64:
+			buf.WriteString(fmt.Sprint(slice.Index(i).Uint()))
+		case reflect.Float64:
+			buf.WriteString(fmt.Sprint(slice.Index(i).Float()))
+		case reflect.Bool:
+			buf.WriteString(fmt.Sprint(slice.Index(i).Bool()))
+		case reflectTime:
+			buf.WriteString(slice.Index(i).Interface().(time.Time).Format(time.RFC3339))
+		default:
+			return fmt.Errorf("unsupported type '[]%s'", sliceOf)
+		}
+		buf.WriteString(delim)
+	}
+	key.SetValue(buf.String()[:buf.Len()-len(delim)])
+	return nil
+}
+
+// reflectWithProperType does the opposite thing as setWithProperType.
+func reflectWithProperType(t reflect.Type, key *Key, field reflect.Value, delim string, allowShadow bool) error {
+	switch t.Kind() {
+	case reflect.String:
+		key.SetValue(field.String())
+	case reflect.Bool:
+		key.SetValue(fmt.Sprint(field.Bool()))
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		key.SetValue(fmt.Sprint(field.Int()))
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		key.SetValue(fmt.Sprint(field.Uint()))
+	case reflect.Float32, reflect.Float64:
+		key.SetValue(fmt.Sprint(field.Float()))
+	case reflectTime:
+		key.SetValue(fmt.Sprint(field.Interface().(time.Time).Format(time.RFC3339)))
+	case reflect.Slice:
+		return reflectSliceWithProperType(key, field, delim, allowShadow)
+	case reflect.Ptr:
+		if !field.IsNil() {
+			return reflectWithProperType(t.Elem(), key, field.Elem(), delim, allowShadow)
+		}
+	default:
+		return fmt.Errorf("unsupported type '%s'", t)
+	}
+	return nil
+}
+
+// CR: copied from encoding/json/encode.go with modifications of time.Time support.
+// TODO: add more test coverage.
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	case reflectTime:
+		t, ok := v.Interface().(time.Time)
+		return ok && t.IsZero()
+	}
+	return false
+}
+
+// StructReflector is the interface implemented by struct types that can extract themselves into INI objects.
+type StructReflector interface {
+	ReflectINIStruct(*File) error
+}
+
+func (s *Section) reflectFrom(val reflect.Value) error {
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+	typ := val.Type()
+
+	for i := 0; i < typ.NumField(); i++ {
+		field := val.Field(i)
+		tpField := typ.Field(i)
+
+		tag := tpField.Tag.Get("ini")
+		if tag == "-" {
+			continue
+		}
+
+		rawName, omitEmpty, allowShadow := parseTagOptions(tag)
+		if omitEmpty && isEmptyValue(field) {
+			continue
+		}
+
+		if r, ok := field.Interface().(StructReflector); ok {
+			return r.ReflectINIStruct(s.f)
+		}
+
+		fieldName := s.parseFieldName(tpField.Name, rawName)
+		if len(fieldName) == 0 || !field.CanSet() {
+			continue
+		}
+
+		if (tpField.Type.Kind() == reflect.Ptr && tpField.Anonymous) ||
+			(tpField.Type.Kind() == reflect.Struct && tpField.Type.Name() != "Time") {
+			// Note: The only error here is section doesn't exist.
+			sec, err := s.f.GetSection(fieldName)
+			if err != nil {
+				// Note: fieldName can never be empty here, ignore error.
+				sec, _ = s.f.NewSection(fieldName)
+			}
+
+			// Add comment from comment tag
+			if len(sec.Comment) == 0 {
+				sec.Comment = tpField.Tag.Get("comment")
+			}
+
+			if err = sec.reflectFrom(field); err != nil {
+				return fmt.Errorf("error reflecting field %q: %v", fieldName, err)
+			}
+			continue
+		}
+
+		key, err := s.GetKey(fieldName)
+		if err != nil {
+			key, _ = s.NewKey(fieldName, "")
+		}
+
+		// Add comment from comment tag
+		if len(key.Comment) == 0 {
+			key.Comment = tpField.Tag.Get("comment")
+		}
+
+		delim := parseDelim(tpField.Tag.Get("delim"))
+		if err = reflectWithProperType(tpField.Type, key, field, delim, allowShadow); err != nil {
+			return fmt.Errorf("error reflecting field %q: %v", fieldName, err)
+		}
+
+	}
+	return nil
+}
+
+// ReflectFrom reflects secion from given struct.
+func (s *Section) ReflectFrom(v interface{}) error {
+	typ := reflect.TypeOf(v)
+	val := reflect.ValueOf(v)
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+		val = val.Elem()
+	} else {
+		return errors.New("cannot reflect from non-pointer struct")
+	}
+
+	return s.reflectFrom(val)
+}
+
+// ReflectFrom reflects file from given struct.
+func (f *File) ReflectFrom(v interface{}) error {
+	return f.Section("").ReflectFrom(v)
+}
+
+// ReflectFromWithMapper reflects data sources from given struct with name mapper.
+func ReflectFromWithMapper(cfg *File, v interface{}, mapper NameMapper) error {
+	cfg.NameMapper = mapper
+	return cfg.ReflectFrom(v)
+}
+
+// ReflectFrom reflects data sources from given struct.
+func ReflectFrom(cfg *File, v interface{}) error {
+	return ReflectFromWithMapper(cfg, v, nil)
+}

--- a/website/docs/r/dns_record.html.markdown
+++ b/website/docs/r/dns_record.html.markdown
@@ -44,6 +44,9 @@ The following arguments are supported:
 * `name` — (Required) The name of the record. The name is an owner name, that is, the name of the node to which this resource record pertains.  
 * `zone` — (Required) Domain zone, encapsulating any nested subdomains.  
 * `recordType` — (Required) The DNS record type.  
-* `active` — (Required,Boolean) Whether the record is active.  
+* `active` — (Ignored,Boolean) Maintained for backward compatibility
 * `ttl` — (Required,Boolean) The TTL is a 32-bit signed integer that specifies the time interval that the resource record may be cached before the source of the information should be consulted again. Zero values are interpreted to mean that the RR can only be used for the transaction in progress, and should not be cached. Zero values can also be used for extremely volatile data.  
-* `target` — (Required) A domain name that specifies the canonical or primary name for the owner. The owner name is an alias.  
+* `target` — (Required) A domain name that specifies the canonical or primary name for the owner. The owner name is an alias.
+
+In addition, Type specific keys define the data makeup of each Record's data
+  

--- a/website/docs/r/dns_zone.html.markdown
+++ b/website/docs/r/dns_zone.html.markdown
@@ -39,6 +39,14 @@ The following arguments are supported:
 * `group` — (Required) The currently selected group ID.   
 * `zone` — (Required) Domain zone, encapsulating any nested subdomains.  
 * `type` — (Required) Whether the zone is primary or secondary.  
-* `masters` — (Required) The names or addresses of the customer’s nameservers from which the zone data should be retrieved.  
+* `masters` — (Required for Secondary) The names or addresses of the customer’s nameservers from which the zone data should be retrieved.  
 * `comment` — (Required) A descriptive comment.  
-* `sign_and_serve` — (Required) Whether DNSSEC Sign&Serve is enabled.  
+* `sign_and_serve` — (Optional) Whether DNSSEC Sign&Serve is enabled. 
+* `sign_and_serve_algorithm` — (Optional) Algorithm used by Sign&Serve.
+* `target` — (Required for Alias) 
+* `tsig_key` — (Optional) TSIG Key used in secure zone transfers
+  * `name` - key name
+  * `algorithm`
+  * `secret`
+* `end_customer_id` — (Optional)
+  


### PR DESCRIPTION
* [ADD] Support the creation of DNS records of type AKAMAICDN (`akamai_dns`) [GH-53]
* [ADD] Support akamai_dns_record Import (`akamai_dns`) [GH-69]
* [FIX] Cannot remove a backup_cname from GTM property (`akamai_gtm`) [GH-124]
* [ADD] DNS Alias Zone Support (`akamai_dns`) [GH-125]
* [ADD] DNS TSIG Key support (`akamai_dns`) [GH-126]
* [ADD] DNS SOA, AKAMAITLC Record Support (`akamai_dns`) [GH-127]
* [FIX] Inverted Parameters - DNS Record Type NAPTR (`akamai_dns`) [GH-130]
* [FIX] Inverted Parameters - DNS Record Type NSEC3 (`akamai_dns`) [GH-131]
* [FIX] Inverted Parameters - DNS Record Type NSEC3PARAM (`akamai_dns`) [GH-132]
* [FIX] Inverted Parameters - DNS Record Type RRSIG (`akamai_dns`) [GH-133]
* [FIX] Inverted Parameters - DNS Record Type DS (`akamai_dns`) [GH-134]
