### PR TITLE
[AT-41][Change] Fixed default group use case

### DIFF
--- a/akamai/data_property_akamai_group.go
+++ b/akamai/data_property_akamai_group.go
@@ -78,6 +78,8 @@ func dataSourcePropertyGroupsRead(d *schema.ResourceData, meta interface{}) erro
 			}
 
 			err = fmt.Errorf("group does not belong to contract %s", contract)
+		} else {
+			group, err = groups.FindGroupId(name)
 		}
 	}
 

--- a/akamai/data_property_akamai_group.go
+++ b/akamai/data_property_akamai_group.go
@@ -66,20 +66,29 @@ func dataSourcePropertyGroupsRead(d *schema.ResourceData, meta interface{}) erro
 		var foundGroups []*papi.Group
 		foundGroups, err := groups.FindGroupsByName(name)
 
-		// Make sure the group belongs to the specified contract
-		if err == nil && contractOk {
-			for _, foundGroup := range foundGroups {
-				for _, c := range foundGroup.ContractIDs {
-					if c == contract.(string) || c == "ctr_"+contract.(string) {
-						group = foundGroup
-						goto groupFound
+		if err == nil {
+			if contractOk {
+				// if contract is specified make sure the group belongs to the specified contract
+				for _, foundGroup := range foundGroups {
+					for _, c := range foundGroup.ContractIDs {
+						if c == contract.(string) || c == "ctr_"+contract.(string) {
+							group = foundGroup
+							goto groupFound
+						}
 					}
 				}
-			}
 
-			err = fmt.Errorf("group does not belong to contract %s", contract)
-		} else {
-			group, err = groups.FindGroupId(name)
+				err = fmt.Errorf("group does not belong to contract %s", contract)
+			} else {
+				// contract is unspecified. if there is only one group return it, if more return an error
+				var groupCount = len(foundGroups)
+				if groupCount == 1 {
+					group = foundGroups[0]
+					goto groupFound
+				} else {
+					err = fmt.Errorf("There is more then one group with name %s, please add contractId to data source definition to select one.", name)
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Fix bug introduced in #94 and reported in https://github.com/terraform-providers/terraform-provider-akamai/issues/168#issuecomment-658888072
Additionally throw an error when there is more than one group with same name - we don't want referenced group to change if someone adds one with same name under different contract.