### PR TITLE
Fixing example usage for provider import

### DIFF
--- a/docs/guides/akamai_provider_auth.md
+++ b/docs/guides/akamai_provider_auth.md
@@ -76,7 +76,7 @@ Terraform 0.13 and later:
 terraform {
   required_providers {
     akamai = {
-      source  = "hashicorp/akamai"
+      source  = "akamai/akamai"
     }
   }
 }


### PR DESCRIPTION
The documentation says to use `hashicorp/akamai` for TF 0.13 or higher to import which is incorrect. It should be `akamai/akamai`.