### PR TITLE
Removing default value comment for `ip_behavior`

### DIFF
--- a/docs/resources/edge_hostname.md
+++ b/docs/resources/edge_hostname.md
@@ -53,7 +53,7 @@ This resource supports these arguments:
 * `product_id` - (Required) A product's unique ID, including the `prd_` prefix.
 * `edge_hostname` - (Required) One or more edge hostnames. The number of edge hostnames must be less than or equal to the number of public hostnames.
 * `certificate` - (Optional) Required only when creating an Enhanced TLS edge hostname. This argument sets the certificate enrollment ID. Edge hostnames for Enhanced TLS end in `edgekey.net`. You can retrieve this ID from the [Certificate Provisioning Service CLI](https://github.com/akamai/cli-cps) .
-* `ip_behavior` - (Required) Which version of the IP protocol to use: `IPV4` for version 4 only, `IPV6_PERFORMANCE` for version 6 only, or `IPV6_COMPLIANCE` for both 4 and 6. The default value is `IPV4`.
+* `ip_behavior` - (Required) Which version of the IP protocol to use: `IPV4` for version 4 only, `IPV6_PERFORMANCE` for version 6 only, or `IPV6_COMPLIANCE` for both 4 and 6.
 
 ### Deprecated arguments
 


### PR DESCRIPTION
Removing default value comment for `ip_behavior`  as there is no default configured in the resource configuration and the documented indicating a default value is confusing on whether it is actually a required field or not.