### PR TITLE
Add missing array type to template variables

### DIFF
--- a/docs/data-sources/property_rules_template.md
+++ b/docs/data-sources/property_rules_template.md
@@ -126,7 +126,7 @@ resource "akamai_property" "example" {
 * `template_file` - (Required) The absolute path to your top-level JSON template file. The top-level template combines smaller, nested JSON templates to form your property rule tree.
 * `variables` - (Optional) A definition of a variable. Variables aren't required and you can use multiple ones if needed. This argument conflicts with the `variable_definition_file` and `variable_values_file` arguments. A `variables` block includes:
     * `name` - The name of the variable used in template.
-    * `type` - The type of variable: `string`, `number`, `bool`, or `jsonBlock`.
+    * `type` - The type of variable: `string`, `number`, `bool`, `jsonArray` or `jsonBlock`.
     * `value` - The value of the variable passed as a string.
 * `variable_definition_file` - (Optional) The absolute path to the file containing variable definitions and defaults. This file follows the syntax used in the [Property Manager CLI](https://github.com/akamai/cli-property-manager). This argument is required if you set `variable_values_file` and conflicts with `variables`.
 * `variable_values_file` - (Optional) The absolute path to the file containing variable values. This file follows the syntax used in the Property Manager CLI. This argument is required if you set `variable_definition_file` and conflicts with `variables`.

--- a/pkg/providers/property/testdata/TestDSRulesTemplate/template_file_not_found.tf
+++ b/pkg/providers/property/testdata/TestDSRulesTemplate/template_file_not_found.tf
@@ -20,6 +20,11 @@ data "akamai_property_rules_template" "test" {
     type = "bool"
   }
   variables {
+    name = "list"
+    value = "[\"foo\", \"bar\", \"baz\"]"
+    type = "jsonArray"
+  }
+  variables {
     name = "options"
     value = "{\"enabled\":true}"
     type = "jsonBlock"

--- a/pkg/providers/property/testdata/TestDSRulesTemplate/template_vars_conflict.tf
+++ b/pkg/providers/property/testdata/TestDSRulesTemplate/template_vars_conflict.tf
@@ -22,6 +22,11 @@ data "akamai_property_rules_template" "test" {
     type = "bool"
   }
   variables {
+    name = "list"
+    value = "[\"foo\", \"bar\", \"baz\"]"
+    type = "jsonArray"
+  }
+  variables {
     name = "options"
     value = "{\"enabled\":true}"
     type = "jsonBlock"

--- a/pkg/providers/property/testdata/TestDSRulesTemplate/template_vars_invalid_value.tf
+++ b/pkg/providers/property/testdata/TestDSRulesTemplate/template_vars_invalid_value.tf
@@ -20,6 +20,11 @@ data "akamai_property_rules_template" "test" {
     type = "bool"
   }
   variables {
+    name = "list"
+    value = "[\"foo\", \"bar\", \"baz\"]"
+    type = "jsonArray"
+  }
+  variables {
     name = "options"
     value = "{\"enabled\":true}"
     type = "jsonBlock"

--- a/pkg/providers/property/testdata/TestDSRulesTemplate/template_vars_map.tf
+++ b/pkg/providers/property/testdata/TestDSRulesTemplate/template_vars_map.tf
@@ -20,6 +20,11 @@ data "akamai_property_rules_template" "test" {
     type = "bool"
   }
   variables {
+    name = "list"
+    value = "[\"foo\", \"bar\", \"baz\"]"
+    type = "jsonArray"
+  }
+  variables {
     name = "options"
     value = "{\"enabled\":true}"
     type = "jsonBlock"


### PR DESCRIPTION
The variables blocks in `akamai_property_rules_template` allows a `jsonBlock`, but an array is an invalid input to this type. This adds a new type `jsonArray` so that the user can template out arrays.