### PR TITLE
Rework note on hostnames syntax change

### DIFF
--- a/docs/resources/property.md
+++ b/docs/resources/property.md
@@ -10,9 +10,6 @@ description: |-
 
 ~> **Note** Version 1.0.0 of the Akamai Terraform Provider is now available for the Provisioning module. To upgrade to the new version, you have to update this resource. See the [migration guide](../guides/1.0_migration.md) for details.
 
-~> **Note** Hostnames syntax changed to block type since 1.5.0. Existing terraform users with hostnames defined in older syntax(1.4.0 or before) need to manually fix their hostnames configuration and existing state if needed. 
-If the state is invalid, users can either re-import the property from scratch or manually modify the state file. 
-
 The `akamai_property` resource represents an Akamai property configuration.
 This resource lets you to create, update, and activate properties on the
 Akamai platform.
@@ -62,7 +59,7 @@ This resource supports these arguments:
 * `product_id` - (Required to create, otherwise Optional) A product's unique ID, including the `prd_` prefix.
 * `hostnames` - (Optional) A mapping of public hostnames to edge hostnames. See the [`akamai_property_hostnames`](../data-sources/property_hostnames.md) data source for details on the necessary DNS configuration.
 
-    ~> **Note** `hostnames` argument now supports a new input block. Make sure you replace your previous input for this argument with the new syntax.
+    ~> **Note** `hostnames` syntax changed to block type in 1.5. Existing Terraform code and state created in 1.4 or older needs to be migrated. The following error is indicative that the state needs to be fixed: `Error: missing expected [`. The easiest way to fix the state is to remove the akamai_property from the state and import it again.
 
     Requires these additional arguments:
 


### PR DESCRIPTION
I think it might make more sense to put the state migration info with the hostnames argument, as it will be a lot more difficult for users to miss that information, considering everyone has to adapt the syntax of the hostnames anyway when they're upgrading to 1.5.