### PR TITLE
ACG and Contract ID in Network Lists #243

### DIFF
--- a/docs/resources/networklist_network_list.md
+++ b/docs/resources/networklist_network_list.md
@@ -41,6 +41,10 @@ The following arguments are supported:
 * `list` : (Optional) A list of IP addresses or locations to be included in the list, added to an existing list, or
   removed from an existing list.
 
+* `group` - (Optional) The Access Control Group ID to be assigned to the network list. If either a contract or group is provided, they must both be provided.
+
+* `contract` - (Optional) The Contract ID to be assigned to the network list. If either a contract or group is provided, they must both be provided.
+
 * `mode` - (Required) A string specifying the interpretation of the `list` parameter. Must be one of the following:
 
   * APPEND - the addresses or locations listed in `list` will be added to the network list

--- a/docs/resources/networklist_network_list.md
+++ b/docs/resources/networklist_network_list.md
@@ -45,6 +45,8 @@ The following arguments are supported:
 
 * `contract` - (Optional) The Contract ID to be assigned to the network list. If either a contract or group is provided, they must both be provided.
 
+* `access_control_group` - (Optional) The Access Control Group name (pretty `{group_name} - {contract_name}.G{group_id}`) to be assigned to the network list. Either `access_control_group` or both `group` with `contract` must be specified when in use. They are mutually exclusive.
+
 * `mode` - (Required) A string specifying the interpretation of the `list` parameter. Must be one of the following:
 
   * APPEND - the addresses or locations listed in `list` will be added to the network list

--- a/pkg/providers/networklists/resource_akamai_networklist_network_list.go
+++ b/pkg/providers/networklists/resource_akamai_networklist_network_list.go
@@ -61,7 +61,7 @@ func resourceNetworkList() *schema.Resource {
 				}, false),
 			},
 			"group": {
-				Type:        schema.TypeString,
+				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "groupId",
 			},
@@ -69,6 +69,11 @@ func resourceNetworkList() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "contractId",
+			},
+			"access_control_group": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "accessControlGroup",
 			},
 			"uniqueid": {
 				Type:        schema.TypeString,
@@ -119,17 +124,25 @@ func resourceNetworkListCreate(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(err)
 	}
 
-	group, err := tools.GetStringValue("group", d)
-	if err != nil && !errors.Is(err, tools.ErrNotFound) {
-		return diag.FromErr(err)
-	}
-	createNetworkList.Group = group
+	accessControlGroup, err := tools.GetStringValue("access_control_group", d)
+	if accessControlGroup != "" {
+		if err != nil && !errors.Is(err, tools.ErrNotFound) {
+			return diag.FromErr(err)
+		}
+		createNetworkList.AccessControlGroup = accessControlGroup
+	} else {
+		group, err := tools.GetIntValue("group", d)
+		if err != nil && !errors.Is(err, tools.ErrNotFound) {
+			return diag.FromErr(err)
+		}
+		createNetworkList.Group = group
 
-	contract, err := tools.GetStringValue("contract", d)
-	if err != nil && !errors.Is(err, tools.ErrNotFound) {
-		return diag.FromErr(err)
+		contract, err := tools.GetStringValue("contract", d)
+		if err != nil && !errors.Is(err, tools.ErrNotFound) {
+			return diag.FromErr(err)
+		}
+		createNetworkList.Contract = contract
 	}
-	createNetworkList.Contract = contract
 
 	getNetworkLists := networklists.GetNetworkListsRequest{}
 	getNetworkLists.Name = name
@@ -242,17 +255,25 @@ func resourceNetworkListUpdate(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(err)
 	}
 
-	group, err := tools.GetStringValue("group", d)
-	if err != nil && !errors.Is(err, tools.ErrNotFound) {
-		return diag.FromErr(err)
-	}
-	updateNetworkList.Group = group
+	accessControlGroup, err := tools.GetStringValue("access_control_group", d)
+	if accessControlGroup != "" {
+		if err != nil && !errors.Is(err, tools.ErrNotFound) {
+			return diag.FromErr(err)
+		}
+		updateNetworkList.AccessControlGroup = accessControlGroup
+	} else {
+		group, err := tools.GetIntValue("group", d)
+		if err != nil && !errors.Is(err, tools.ErrNotFound) {
+			return diag.FromErr(err)
+		}
+		updateNetworkList.Group = group
 
-	contract, err := tools.GetStringValue("contract", d)
-	if err != nil && !errors.Is(err, tools.ErrNotFound) {
-		return diag.FromErr(err)
+		contract, err := tools.GetStringValue("contract", d)
+		if err != nil && !errors.Is(err, tools.ErrNotFound) {
+			return diag.FromErr(err)
+		}
+		updateNetworkList.Contract = contract
 	}
-	updateNetworkList.Contract = contract
 
 	listRequest := networklists.GetNetworkListRequest{}
 	listRequest.UniqueID = d.Id()

--- a/pkg/providers/networklists/resource_akamai_networklist_network_list.go
+++ b/pkg/providers/networklists/resource_akamai_networklist_network_list.go
@@ -60,6 +60,16 @@ func resourceNetworkList() *schema.Resource {
 					Remove,
 				}, false),
 			},
+			"group": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "groupId",
+			},
+			"contract": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "contractId",
+			},
 			"uniqueid": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -108,6 +118,18 @@ func resourceNetworkListCreate(ctx context.Context, d *schema.ResourceData, m in
 	if err != nil && !errors.Is(err, tools.ErrNotFound) {
 		return diag.FromErr(err)
 	}
+
+	group, err := tools.GetStringValue("group", d)
+	if err != nil && !errors.Is(err, tools.ErrNotFound) {
+		return diag.FromErr(err)
+	}
+	createNetworkList.Group = group
+
+	contract, err := tools.GetStringValue("contract", d)
+	if err != nil && !errors.Is(err, tools.ErrNotFound) {
+		return diag.FromErr(err)
+	}
+	createNetworkList.Contract = contract
 
 	getNetworkLists := networklists.GetNetworkListsRequest{}
 	getNetworkLists.Name = name
@@ -219,6 +241,18 @@ func resourceNetworkListUpdate(ctx context.Context, d *schema.ResourceData, m in
 	if err != nil && !errors.Is(err, tools.ErrNotFound) {
 		return diag.FromErr(err)
 	}
+
+	group, err := tools.GetStringValue("group", d)
+	if err != nil && !errors.Is(err, tools.ErrNotFound) {
+		return diag.FromErr(err)
+	}
+	updateNetworkList.Group = group
+
+	contract, err := tools.GetStringValue("contract", d)
+	if err != nil && !errors.Is(err, tools.ErrNotFound) {
+		return diag.FromErr(err)
+	}
+	updateNetworkList.Contract = contract
 
 	listRequest := networklists.GetNetworkListRequest{}
 	listRequest.UniqueID = d.Id()

--- a/pkg/providers/networklists/resource_akamai_networklist_network_list_test.go
+++ b/pkg/providers/networklists/resource_akamai_networklist_network_list_test.go
@@ -85,3 +85,83 @@ func TestAccAkamaiNetworkList_res_basic(t *testing.T) {
 	})
 
 }
+
+func TestAccAkamaiNetworkList_with_ACG(t *testing.T) {
+	t.Run("access control group", func(t *testing.T) {
+		client := &mocknetworklists{}
+
+		crnl := networklists.CreateNetworkListResponse{}
+		expectJSCNL := compactJSON(loadFixtureBytes("testdata/TestResNetworkList/NetworkList.json"))
+		json.Unmarshal([]byte(expectJSCNL), &crnl)
+
+		cu := networklists.UpdateNetworkListResponse{}
+		expectJSU := compactJSON(loadFixtureBytes("testdata/TestResNetworkList/NetworkLists.json"))
+		json.Unmarshal([]byte(expectJSU), &cu)
+
+		cr := networklists.GetNetworkListResponse{}
+		expectJS := compactJSON(loadFixtureBytes("testdata/TestResNetworkList/NetworkList.json"))
+		json.Unmarshal([]byte(expectJS), &cr)
+
+		crl := networklists.GetNetworkListsResponse{}
+		expectJSL := compactJSON(loadFixtureBytes("testdata/TestResNetworkList/NetworkLists.json"))
+		json.Unmarshal([]byte(expectJSL), &crl)
+
+		cd := networklists.RemoveNetworkListResponse{}
+		expectJSD := compactJSON(loadFixtureBytes("testdata/TestResNetworkList/Empty.json"))
+		json.Unmarshal([]byte(expectJSD), &cd)
+
+		client.On("CreateNetworkList",
+			mock.Anything, // ctx is irrelevant for this test
+			networklists.CreateNetworkListRequest{Name: "Voyager Call Center Whitelist", Type: "IP", Description: "Notes about this network list", List: []string{"10.1.8.23", "10.3.5.67"}, AccessControlGroup: " Kona Site Defender - C-D5TW8R - C-D5TW8R.G31325"},
+		).Return(&crnl, nil)
+
+		client.On("GetNetworkList",
+			mock.Anything, // ctx is irrelevant for this test
+			networklists.GetNetworkListRequest{UniqueID: "2275_VOYAGERCALLCENTERWHITELI"},
+		).Return(&cr, nil)
+
+		client.On("GetNetworkLists",
+			mock.Anything, // ctx is irrelevant for this test
+			networklists.GetNetworkListsRequest{Name: "Voyager Call Center Whitelist", Type: "IP"},
+		).Return(&crl, nil)
+
+		client.On("UpdateNetworkList",
+			mock.Anything, // ctx is irrelevant for this test
+			networklists.UpdateNetworkListRequest{Name: "Voyager Call Center Whitelist", Type: "IP", Description: "Notes about this network list", SyncPoint: 0, List: []string{"10.1.8.23", "10.3.5.67"}, UniqueID: "2275_VOYAGERCALLCENTERWHITELI", Group: 31325, Contract: "C-D5TW8R"},
+		).Return(&cu, nil)
+
+		client.On("RemoveNetworkList",
+			mock.Anything, // ctx is irrelevant for this test
+			networklists.RemoveNetworkListRequest{UniqueID: "2275_VOYAGERCALLCENTERWHITELI"},
+		).Return(&cd, nil)
+
+		useClient(client, func() {
+			resource.Test(t, resource.TestCase{
+				IsUnitTest: true,
+				Providers:  testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: loadFixtureString("testdata/TestResNetworkList/access_group.tf"),
+						Check: resource.ComposeAggregateTestCheckFunc(
+							resource.TestCheckResourceAttr("akamai_networklist_network_list.test", "name", "Voyager Call Center Whitelist"),
+							resource.TestCheckResourceAttr("akamai_networklist_network_list.test", "access_control_group", " Kona Site Defender - C-D5TW8R - C-D5TW8R.G31325"),
+						),
+						ExpectNonEmptyPlan: true,
+					},
+					{
+						Config: loadFixtureString("testdata/TestResNetworkList/update_access_group.tf"),
+						Check: resource.ComposeAggregateTestCheckFunc(
+							resource.TestCheckResourceAttr("akamai_networklist_network_list.test", "name", "Voyager Call Center Whitelist"),
+							resource.TestCheckResourceAttr("akamai_networklist_network_list.test", "group", "31325"),
+							resource.TestCheckResourceAttr("akamai_networklist_network_list.test", "contract", "C-D5TW8R"),
+						),
+						ExpectNonEmptyPlan: true,
+					},
+				},
+			})
+		})
+
+		client.AssertExpectations(t)
+	})
+
+}

--- a/pkg/providers/networklists/testdata/TestResNetworkList/access_group.tf
+++ b/pkg/providers/networklists/testdata/TestResNetworkList/access_group.tf
@@ -1,0 +1,15 @@
+provider "akamai" {
+  edgerc = "~/.edgerc"
+}
+
+
+resource "akamai_networklist_network_list" "test" {
+   name =  "Voyager Call Center Whitelist"
+    type =  "IP"
+    description = "Notes about this network list"
+    access_control_group = " Kona Site Defender - C-D5TW8R - C-D5TW8R.G31325"
+  
+    list = ["10.1.8.23","10.3.5.67"] 
+    mode = "REPLACE"
+   }
+

--- a/pkg/providers/networklists/testdata/TestResNetworkList/update_access_group.tf
+++ b/pkg/providers/networklists/testdata/TestResNetworkList/update_access_group.tf
@@ -1,0 +1,16 @@
+provider "akamai" {
+  edgerc = "~/.edgerc"
+}
+
+
+resource "akamai_networklist_network_list" "test" {
+   name =  "Voyager Call Center Whitelist"
+    type =  "IP"
+    description = "Notes about this network list"
+    group = 31325
+    contract = "C-D5TW8R"
+  
+    list = ["10.1.8.23","10.3.5.67"] 
+    mode = "REPLACE"
+   }
+


### PR DESCRIPTION
This fixes #243 but before it is and approved and merged changes need to be done to the [CreateNetworkListRequest](https://github.com/akamai/AkamaiOPEN-edgegrid-golang/blob/v2/pkg/networklists/network_list.go#L98) and [UpdateNetworkListRequest](https://github.com/akamai/AkamaiOPEN-edgegrid-golang/blob/v2/pkg/networklists/network_list.go#L105) structs in [AkamaiOPEN-edgegrid-golang](https://github.com/akamai/AkamaiOPEN-edgegrid-golang/tree/v2) to add two optional parameters:

```go
Group       string   `json:"groupId,omitempty"`
Contract    string   `json:"contractId,omitempty"`
```

Let me know if I should enrich test cases with these new parameters and create a tiny PR to the aforementioned repository.
Thanks.