### PR TITLE
Release/v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # RELEASE NOTES
 
+## 1.6.1 (Jul 25, 2021)
+
+#### BUG FIXES:
+* DNS
+  * Fixed contract id not being set in zone import and made group optional ([#242](https://github.com/akamai/terraform-provider-akamai/issues/242))
+* GTM
+  * Fixed documentation mismatch with optional/required fields on nested objects for `akamai_gmt_property` resource ([#240](https://github.com/akamai/terraform-provider-akamai/issues/240))
+* PAPI
+  * Fixed issue with property hostnames list changing order in diff ([#230](https://github.com/akamai/terraform-provider-akamai/issues/230))
+  * Fixed idempotency issue on `akamai_property` resource ([#226](https://github.com/akamai/terraform-provider-akamai/issues/226))
+  * Fixed issue with terraform showing misleading diff on `rules` field in `akamai_property` ([#234](https://github.com/akamai/terraform-provider-akamai/issues/234))
+* CPS
+  * Added `sans` field on `akamai_cps_dv_validation` to enable resending acknowledgement on after SANS are updated 
+
+#### FEATURES/ENHANCEMENTS:
+* CPS
+  * `akamai_cps_dv_enrollment` now accepts `contract_id` with `ctr_` prefix
+
 ## 1.6.0 (June 21, 2021)
 
 #### BREAKING CHANGES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # RELEASE NOTES
 
-## 1.6.1 (Jul 25, 2021)
+## 1.6.1 (Jul 21, 2021)
 
 #### BUG FIXES:
 * DNS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,8 @@
     * akamai_appsec_rule
 
 * PAPI
-  * New optional parameter, which allows to import a specific property version. Additional information in [Property resource](docs/resources/property.md#import) 
+  * New optional parameter, which allows to import a specific property version. 
+    Additional information in [Property resource](https://registry.terraform.io/providers/akamai/akamai/latest/docs/resources/property#import) 
 
 ## 1.5.1 (Apr 21, 2021)
 

--- a/docs/data-sources/appsec_attack_groups.md
+++ b/docs/data-sources/appsec_attack_groups.md
@@ -1,6 +1,6 @@
 ---
 layout: "akamai"
-page_title: "Akamai: KRS Attack Groups
+page_title: "Akamai: KRS Attack Groups"
 subcategory: "Application Security"
 description: |-
  KRS Attack Groups

--- a/docs/data-sources/appsec_eval_rules.md
+++ b/docs/data-sources/appsec_eval_rules.md
@@ -1,6 +1,6 @@
 ---
 layout: "akamai"
-page_title: "Akamai: KRS Eval Rule
+page_title: "Akamai: KRS Eval Rule"
 subcategory: "Application Security"
 description: |-
  KRS Eval Rules

--- a/docs/data-sources/appsec_rules.md
+++ b/docs/data-sources/appsec_rules.md
@@ -1,6 +1,6 @@
 ---
 layout: "akamai"
-page_title: "Akamai: KRS Rules
+page_title: "Akamai: KRS Rules"
 subcategory: "Application Security"
 description: |-
  KRS Rules

--- a/docs/data-sources/cp_code.md
+++ b/docs/data-sources/cp_code.md
@@ -1,7 +1,7 @@
 ---
 layout: "akamai"
 page_title: "Akamai: cp_code"
-subcategory: "Provisioning"
+subcategory: "Property Provisioning"
 description: |-
  CP Code
 ---

--- a/docs/data-sources/properties.md
+++ b/docs/data-sources/properties.md
@@ -1,7 +1,7 @@
 ---
 layout: "akamai"
 page_title: "Akamai: akamai_properties"
-subcategory: "Provisioning"
+subcategory: "Property Provisioning"
 description: |-
  Properties
 ---
@@ -9,8 +9,8 @@ description: |-
 # akamai_properties
 
 
-Use the `akamai_properties` data source to query and retrieve the list of properties for a group and contract 
-based on the [EdgeGrid API client token](https://developer.akamai.com/getting-started/edgegrid) you're using. 
+Use the `akamai_properties` data source to query and retrieve the list of properties for a group and contract
+based on the [EdgeGrid API client token](https://developer.akamai.com/getting-started/edgegrid) you're using.
 
 ## Example usage
 
@@ -32,7 +32,7 @@ output "my_property_list" {
 
 This data source supports these arguments:
 
-* `contract_id` - (Required) A contract's unique ID, including the `ctr_` prefix. 
+* `contract_id` - (Required) A contract's unique ID, including the `ctr_` prefix.
 * `group_id` - (Required) A group's unique ID, including the `grp_` prefix.
 
 ## Attributes reference

--- a/docs/data-sources/property.md
+++ b/docs/data-sources/property.md
@@ -1,7 +1,7 @@
 ---
 layout: "akamai"
 page_title: "Akamai: akamai_property"
-subcategory: "Provisioning"
+subcategory: "Property Provisioning"
 description: |-
  Property
 ---

--- a/docs/data-sources/property_hostnames.md
+++ b/docs/data-sources/property_hostnames.md
@@ -1,7 +1,7 @@
 ---
 layout: "akamai"
 page_title: "Akamai: akamai_property_hostnames"
-subcategory: "Provisioning"
+subcategory: "Property Provisioning"
 description: |-
  Property hostnames
 ---

--- a/docs/data-sources/property_products.md
+++ b/docs/data-sources/property_products.md
@@ -1,7 +1,7 @@
 ---
 layout: "akamai"
 page_title: "Akamai: akamai_property_products"
-subcategory: "Provisioning"
+subcategory: "Property Provisioning"
 description: |-
  Property products
 ---
@@ -9,7 +9,7 @@ description: |-
 # akamai_property_products
 
 
-Use the `akamai_property_products` data source to list the products included on a contract. 
+Use the `akamai_property_products` data source to list the products included on a contract.
 
 ## Example usage
 
@@ -29,7 +29,7 @@ output "property_match" {
 
 This data source supports this argument:
 
-* `contract_id` - (Required) A contract's unique ID, including the `ctr_` prefix. 
+* `contract_id` - (Required) A contract's unique ID, including the `ctr_` prefix.
 
 ## Attributes reference
 

--- a/docs/data-sources/property_rule_formats.md
+++ b/docs/data-sources/property_rule_formats.md
@@ -1,19 +1,19 @@
 ---
 layout: "akamai"
 page_title: "Akamai: akamai_property_rule_formats"
-subcategory: "Provisioning"
+subcategory: "Property Provisioning"
 description: |-
  Properties rule formats
 ---
 
 # akamai_property_rule_formats
 
-Use the `akamai_property_rule_formats` data source to query the list of 
-known rule formats. 
-You use rule formats to [freeze](https://developer.akamai.com/api/core_features/property_manager/v1.html#freezerf) or 
+Use the `akamai_property_rule_formats` data source to query the list of
+known rule formats.
+You use rule formats to [freeze](https://developer.akamai.com/api/core_features/property_manager/v1.html#freezerf) or
 [update](https://developer.akamai.com/api/core_features/property_manager/v1.html#updaterf) the versioned set of behaviors
-and criteria a rule tree invokes. Without this mechanism, behaviors and criteria 
-would update automatically and generate unexpected errors. 
+and criteria a rule tree invokes. Without this mechanism, behaviors and criteria
+would update automatically and generate unexpected errors.
 
 ## Example usage
 
@@ -36,7 +36,7 @@ There are no arguments available for this data source.
 
 This data source returns this attribute:
 
-* `formats` - A list of supported rule format identifiers. For example: 
+* `formats` - A list of supported rule format identifiers. For example:
 
 ```json
         [

--- a/docs/data-sources/property_rules.md
+++ b/docs/data-sources/property_rules.md
@@ -1,17 +1,17 @@
 ---
 layout: "akamai"
 page_title: "Akamai: akamai_property_rules"
-subcategory: "Provisioning"
+subcategory: "Property Provisioning"
 description: |-
  Property rule tree
 ---
 
 # akamai_property_rules
 
-~> **Note** Version 1.0.0 of the Akamai Terraform Provider is now available for the Property Provisioning module. To upgrade to the new version, you have to update this data source. See [Upgrade to Version 1.0.0](../guides/1.0_migration.md) for details. 
+~> **Note** Version 1.0.0 of the Akamai Terraform Provider is now available for the Property Provisioning module. To upgrade to the new version, you have to update this data source. See [Upgrade to Version 1.0.0](../guides/1.0_migration.md) for details.
 
-Use the `akamai_property_rules` data source to query and retrieve the rule tree of 
-an existing property version. This data source lets you search across the contracts 
+Use the `akamai_property_rules` data source to query and retrieve the rule tree of
+an existing property version. This data source lets you search across the contracts
 and groups you have access to.
 
 ## Basic usage
@@ -35,9 +35,9 @@ output "property_match" {
 
 This data source supports these arguments:
 
-* `contract_id` - (Required) A contract's unique ID, including the `ctr_` prefix. 
+* `contract_id` - (Required) A contract's unique ID, including the `ctr_` prefix.
 * `group_id` - (Required) A group's unique ID, including the `grp_` prefix.
-* `property_id` - (Required) A property's unique ID, including the `prp_` prefix. 
+* `property_id` - (Required) A property's unique ID, including the `prp_` prefix.
 * `version` - (Optional) The version to return. Returns the latest version by default.
 
 ## Attributes reference

--- a/docs/data-sources/property_rules_template.md
+++ b/docs/data-sources/property_rules_template.md
@@ -1,32 +1,32 @@
 ---
 layout: "akamai"
 page_title: "Akamai: akamai_property_rules_template"
-subcategory: "Provisioning"
+subcategory: "Property Provisioning"
 description: |-
  Property Rules Template
 ---
 
 # akamai_property_rules_template
 
-The `akamai_property_rules_template` data source lets you configure a rule tree through the use of JSON template files. A rule tree is a nested block of property 
-rules in JSON format that include match criteria and behaviors. 
+The `akamai_property_rules_template` data source lets you configure a rule tree through the use of JSON template files. A rule tree is a nested block of property
+rules in JSON format that include match criteria and behaviors.
 
 With this data source you define the location of the JSON template files and provide information about any user-defined variables included within the templates.
 
 The template format used in this data source matches those used in the [Property Manager CLI](https://learn.akamai.com/en-us/learn_akamai/getting_started_with_akamai_developers/developer_tools/getstartedpmcli.html#addanewsnippet).
 
-You can pass user-defined variables by supplying either: 
+You can pass user-defined variables by supplying either:
 
-* paths to `variableDefinitions.json` and `variables.json` with syntax used in Property Manager CLI, or 
+* paths to `variableDefinitions.json` and `variables.json` with syntax used in Property Manager CLI, or
 * a set of Terraform variables.
 
 ## Referencing sub-files from a template
-You can split each template out into a series of smaller template files. To add 
-them to this data source, you need to include them in the currently loaded file, 
-which corresponds to the value in the `template_file` argument.  For example, to 
-include `example-file.json` from the `property-snippets` directory, use this syntax 
+You can split each template out into a series of smaller template files. To add
+them to this data source, you need to include them in the currently loaded file,
+which corresponds to the value in the `template_file` argument.  For example, to
+include `example-file.json` from the `property-snippets` directory, use this syntax
 including the quotes: `"#include:example-file.json"`.  Make sure the `property-snippets` folder contains only `.json` files.
-All files are resolved in relation to the directory that contains the starting template file. 
+All files are resolved in relation to the directory that contains the starting template file.
 
 ## Inserting variables in a template
 You can also add variables to a template by using a string like `“${env.<variableName>}"`. You'll need the quotes here too.  
@@ -113,7 +113,7 @@ resource "akamai_property" "example" {
     group_id    = var.groupid
     hostnames = {
       "example.org" = "example.org.edgesuite.net"
-      "www.example.org" = "example.org.edgesuite.net" 
+      "www.example.org" = "example.org.edgesuite.net"
       "sub.example.org" = "sub.example.org.edgesuite.net"
     }
     rule_format = "v2020-03-04"

--- a/docs/guides/get_started_property.md
+++ b/docs/guides/get_started_property.md
@@ -7,7 +7,7 @@ description: |-
 
 # Property Provisioning Module Guide
 
-You can use Property Provisioning module resources and data sources to create,
+You can use the Property Provisioning module resources and data sources to create,
 deploy, activate, and manage properties, edge hostnames, and content
 provider (CP) codes.
 
@@ -15,18 +15,18 @@ For more information about properties, see the [Property Manager documentation](
 
 ## Prerequisites
 
-Before you can create a property, you need to complete the tasks in the 
-[Get Started with the Akamai Provider](../guides/get_started_provider.md) 
-guide. Be sure you have the contract and group IDs you retrieved available. You'll 
+Before you can create a property, you need to complete the tasks in the
+[Get Started with the Akamai Provider](../guides/get_started_provider.md)
+guide. Be sure you have the contract and group IDs you retrieved available. You'll
 need them to set up the Property Provisioning module.
 
-## Property Provisioning Workflow 
+## Property Provisioning Workflow
 
-To set up the Property Provisioning module, you need to: 
+To set up the Property Provisioning module, you need to:
 
 * [Retrieve the product ID](#retrieve-the-product-id). This is the ID for the product you are using, like Ion or Adaptive Media Delivery.
 * [Add or create an edge hostname](#add-an-edge-hostname).
-* [Set up rules for your property](#set-up-property-rules). A separate `rules.json` file contains the base rules for the property. 
+* [Set up rules for your property](#set-up-property-rules). A separate `rules.json` file contains the base rules for the property.
 * [Import or create a property](#import-or-create-a-property).
 * [Apply your property changes](#apply-your-property-changes). This step adds the property to your Terraform configuration.
 * [Activate your property](#activate-your-property). Once you apply your property changes, you have to activate the property configuration for it to be live.
@@ -40,8 +40,8 @@ Akamai product you are using. See the [Akamai Product ID](../guides/appendix.md#
 
 ## Add an edge hostname
 
-You use the [akamai_edge_hostname](../resources/property_edge_hostname.md) resource to 
-reuse an existing edge hostname or create a new one. 
+You use the [akamai_edge_hostname](../resources/property_edge_hostname.md) resource to
+reuse an existing edge hostname or create a new one.
 
 To create different hostname types, you need to change the domain suffix
 for the `edge_hostname` attribute. See [Domain Suffixes for Different Edge Hostname Types](../guides/appendix.md#domain-suffixes-for-different-edge-hostname-types)
@@ -69,7 +69,7 @@ resource "akamai_edge_hostname" "example" {
 
 ### Secure hostnames
 
-To create a secure hostname, you also need the `certificate` attribute, which is 
+To create a secure hostname, you also need the `certificate` attribute, which is
 the certificate enrollment ID you can retrieve from the [Certificate Provisioning System CLI](https://github.com/akamai/cli-cps). Here's an example:
 
 ```hcl
@@ -92,11 +92,11 @@ As a best practice, you should store the rule tree as a JSON file on disk and in
 
 ```hcl
 locals {
-	json = file("${path.module}/rules.json") 
+	json = file("${path.module}/rules.json")
 }
 ```
 
-You can now use `local.json` to reference the file contents in the `akamai_property.rules` argument. Or you can embed the file reference directly in the `akamai_property` resource using the `rules` attribute: 
+You can now use `local.json` to reference the file contents in the `akamai_property.rules` argument. Or you can embed the file reference directly in the `akamai_property` resource using the `rules` attribute:
 
 ```
 rules = file("${path.module}/rules.json")
@@ -105,7 +105,7 @@ rules = file("${path.module}/rules.json")
 Before continuing with the next step, run `terraform plan` and resolve any errors or warnings. See [Command: plan](https://www.terraform.io/docs/commands/plan.html) for more information about this Terraform command.
 
 ## Import or create a property
-You can either import an existing property or create a new one with Terraform: 
+You can either import an existing property or create a new one with Terraform:
 
 ### Import a property
 
@@ -115,9 +115,9 @@ To import an existing property into Terraform you have to export the `rules.json
 
 You'll then need to create an `akamai_property` resource that pulls in the `rules.json`.
 
-You can use the `akamai_property_rules` data source to retrieve an existing rule 
-template. It reads the server's copy of the rules then generates output in a format 
-that you can save in a JSON file. If your rule template includes variables, you'll 
+You can use the `akamai_property_rules` data source to retrieve an existing rule
+template. It reads the server's copy of the rules then generates output in a format
+that you can save in a JSON file. If your rule template includes variables, you'll
 have to set them up again.
 
 ### Create a property
@@ -127,13 +127,12 @@ to represent your property. Add this new block to your `akamai.tf` file
 after the `provider` block.
 
 To define the entire configuration, start by opening the resource block
-and give it a name, like `example`. Within the new block, you set the name 
-of the property, contact email, product ID, group ID, CP code, property hostname,
- and edge hostnames.
+and give it a name, like `example`. Within the new block, you set the name
+of the property, product ID, group ID, property hostname, and edge hostnames.
 
-Finally, you set up the property rules. You first specify the 
+Finally, you set up the property rules. You first specify the
 [rule format argument](../resources/property.md),
-then add the path to the `rules.json` file. You can set a variable for the path, like `${path.module}`. 
+then add the path to the `rules.json` file. You can set a variable for the path, like `${path.module}`.
 
 Once you're done, your property should look like this:
 
@@ -159,24 +158,24 @@ resource "akamai_property" "example" {
 ```
 
 Before continuing with the next step, run `terraform plan` and resolve any errors or warnings. See [Command: plan](https://www.terraform.io/docs/commands/plan.html) for more information about this Terraform command.
- 
+
 
 ## Apply your property changes
 
-To actually add the property to your Terraform configuration, you need to 
+To actually add the property to your Terraform configuration, you need to
 tell Terraform to apply the changes outlined in the plan. To do this, run
  `terraform apply` in the terminal.
 
 Once the command completes, your new property is available. You can verify
 this in [Akamai Control Center](https://control.akamai.com/) or by using the
-[Property Manager CLI](https://github.com/akamai/cli-property-manager). 
+[Property Manager CLI](https://github.com/akamai/cli-property-manager).
 
 However, you still have to activate the property configuration for it to be live.
 
 ## Activate your property
 
-Once you’re satisfied with a property version, an activation deploys it to 
-either the Akamai staging or production network. You activate a specific version, 
+Once you’re satisfied with a property version, an activation deploys it to
+either the Akamai staging or production network. You activate a specific version,
 but the same version can be activated separately more than once.
 
 ### Create your property activation resource
@@ -190,7 +189,7 @@ You need following to set up this resource:
 
 * property ID and version, which you can set from the `akamai_property` resource.
 
-* network, which is either `STAGING` or `PRODUCTION`. You should activate the property on staging first to verify that everything works as expected before activating on production. 
+* network, which is either `STAGING` or `PRODUCTION`. You should activate the property on staging first to verify that everything works as expected before activating on production.
 
 * The email addresses to send activation updates to.
 
@@ -224,11 +223,11 @@ Property Provisioning resources.
 
 You can use rule templates to insert values from Akamai Provider resources and data sources into your `rules.json` file.
 
-The `akamai_property_rules_template` data source supports variable 
+The `akamai_property_rules_template` data source supports variable
 replacement and the use of snippet templates from the Property Manager CLI.
 
-You may need to use different rule sets with different properties. To do this you 
-need to maintain a base rule set and then import individual rule sets. You'll first 
+You may need to use different rule sets with different properties. To do this you
+need to maintain a base rule set and then import individual rule sets. You'll first
 need to create a directory structure, like this:
 
 ```dir
@@ -238,8 +237,8 @@ rules/snippets/performance.json
 …
 ```
 
-The `rules` directory contains a single file, `main.json` and a `snippets` 
-subdirectory that contains all of the smaller JSON rule files, or snippets. In the 
+The `rules` directory contains a single file, `main.json` and a `snippets`
+subdirectory that contains all of the smaller JSON rule files, or snippets. In the
 `main.json` file, you set up a basic template for your JSON, like this:
 
 ```json
@@ -258,8 +257,8 @@ subdirectory that contains all of the smaller JSON rule files, or snippets. In t
 }
 ```
 
-This enables the rules template to process the `rules.json` and pull each 
-fragment that's referenced, like `routing.json`. The rendered output can be added 
+This enables the rules template to process the `rules.json` and pull each
+fragment that's referenced, like `routing.json`. The rendered output can be added
 to `akamai_property` resources.
 
 ```hcl

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ Traffic Management configurations.
 
 !> Version 1.0.0 of the Akamai Terraform Provider is a major release that's currently available for the Provisioning module. Before upgrading, you need to make changes to some of your Provisioning resources and data sources. See [Upgrade to Version 1.0.0](guides/1.0_migration.md) for details.
 
-Last updated: June 2021.
+Last updated: July 2021.
 
 ## Migrate to the newest version
 

--- a/docs/resources/appsec_attack_group.md
+++ b/docs/resources/appsec_attack_group.md
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 * `attack_group_action` - (Required) The action to be taken: `alert` to record the trigger of the event, `deny` to block the request, `deny_custom_{custom_deny_id}` to execute a custom deny action, or `none` to take no action.
 
-* `condition_exception` - (Required) The name of a file containing a JSON-formatted description of the conditions and exceptions to use ([format](https://developer.akamai.com/api/cloud_security/application_security/v1.html#putattackgroupconditionexception)).
+* `condition_exception` - (Optional) The name of a file containing a JSON-formatted description of the conditions and exceptions to use ([format](https://developer.akamai.com/api/cloud_security/application_security/v1.html#putattackgroupconditionexception)).
 
 ## Attributes Reference
 

--- a/docs/resources/appsec_eval_rule.md
+++ b/docs/resources/appsec_eval_rule.md
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 * `rule_action` - (Required) The action to be taken: `alert` to record the trigger of the event, `deny` to block the request, `deny_custom_{custom_deny_id}` to execute a custom deny action, or `none` to take no action.
 
-* `condition_exception` - (Required) The name of a file containing a JSON-formatted description of the conditions and exceptions to use ([format](https://developer.akamai.com/api/cloud_security/application_security/v1.html#putevalconditionsexceptions))
+* `condition_exception` - (Optional) The name of a file containing a JSON-formatted description of the conditions and exceptions to use ([format](https://developer.akamai.com/api/cloud_security/application_security/v1.html#putevalconditionsexceptions))
 
 ## Attributes Reference
 

--- a/docs/resources/appsec_rule.md
+++ b/docs/resources/appsec_rule.md
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 * `rule_action` - (Required) The action to be taken: `alert` to record the trigger of the event, `deny` to block the request, `deny_custom_{custom_deny_id}` to execute a custom deny action, or `none` to take no action.
 
-* `condition_exception` - (Required) The name of a file containing a JSON-formatted description of the conditions and exceptions to use ([format](https://developer.akamai.com/api/cloud_security/application_security/v1.html#putconditionexception))
+* `condition_exception` - (Optional) The name of a file containing a JSON-formatted description of the conditions and exceptions to use ([format](https://developer.akamai.com/api/cloud_security/application_security/v1.html#putconditionexception))
 
 ## Attributes Reference
 

--- a/docs/resources/cp_code.md
+++ b/docs/resources/cp_code.md
@@ -1,16 +1,16 @@
 ---
 layout: "akamai"
 page_title: "Akamai: CP Code"
-subcategory: "Provisioning"
+subcategory: "Property Provisioning"
 description: |-
   CP Code
 ---
 
 # akamai_cp_code
 
-~> **Note** Version 1.0.0 of the Akamai Terraform Provider is now available for the Property Provisioning module. To upgrade to the new version, you have to update this resource. See [Upgrade to Version 1.0.0](../guides/1.0_migration.md) for details. 
+~> **Note** Version 1.0.0 of the Akamai Terraform Provider is now available for the Property Provisioning module. To upgrade to the new version, you have to update this resource. See [Upgrade to Version 1.0.0](../guides/1.0_migration.md) for details.
 
-The `akamai_cp_code` resource lets you create or reuse content provider (CP) codes.  CP codes track web traffic handled by Akamai servers. Akamai gives you a CP code when you purchase a product. You need this code when you activate associated properties. 
+The `akamai_cp_code` resource lets you create or reuse content provider (CP) codes.  CP codes track web traffic handled by Akamai servers. Akamai gives you a CP code when you purchase a product. You need this code when you activate associated properties.
 
 You can create additional CP codes to support more detailed billing and reporting functions.
 
@@ -58,7 +58,7 @@ resource "akamai_cp_code" "example_cp" {
 The following arguments are supported:
 
 * `name` - (Required) A descriptive label for the CP code. If you're creating a new CP code, the name can’t include commas, underscores, quotes, or any of these special characters: ^ # %.
-* `contract_id` - (Required) A contract's unique ID, including the `ctr_` prefix. 
+* `contract_id` - (Required) A contract's unique ID, including the `ctr_` prefix.
 * `group_id` - (Required) A group's unique ID, including the `grp_` prefix.
 * `product_id` - (Required) A product's unique ID, including the `prd_` prefix.
 
@@ -82,8 +82,8 @@ resource "akamai_cp_code" "example" {
   }
 ```
 
-You can import your Akamai CP codes using a comma-delimited string of the CP code, 
-contract, and group IDs. You have to enter the IDs in this order: 
+You can import your Akamai CP codes using a comma-delimited string of the CP code,
+contract, and group IDs. You have to enter the IDs in this order:
 
 `cpcode_id,contract_id,group_id`
 

--- a/docs/resources/cps_dv_enrollment.md
+++ b/docs/resources/cps_dv_enrollment.md
@@ -96,7 +96,7 @@ output "enrollment_id" {
 
 The following arguments are supported:
 
-* `contract_id` - (Required) A contract's unique ID, without the `ctr_` prefix.
+* `contract_id` - (Required) A contract's unique ID, optionally with the `ctr_` prefix.
 * `common_name` - (Required) The fully qualified domain name (FQDN) for which you plan to use your certificate. The domain name you specify here must be owned or have legal rights to use the domain by the company you specify as `organization`. The company that owns the domain name must be a legally incorporated entity and be active and in good standing.
 * `sans` - (Optional) Additional common names to create a Subject Alternative Names (SAN) list.
 * `secure_network` - (Required) The type of deployment network you want to use. `standard-tls` deploys your certificate to Akamai’s standard secure network, but it isn't PCI compliant. `enhanced-tls` deploys your certificate to Akamai’s more secure network with PCI compliance capability.
@@ -211,7 +211,7 @@ resource "akamai_cps_dv_enrollment" "example" {
 ```
 
 You can import your Akamai DV enrollment using a comma-delimited string of the enrollment ID and  
-contract ID, without the `ctr_` prefix. You have to enter the IDs in this order:
+contract ID, optionally with the `ctr_` prefix. You have to enter the IDs in this order:
 
 `enrollment_id,contract_id`
 

--- a/docs/resources/cps_dv_enrollment.md
+++ b/docs/resources/cps_dv_enrollment.md
@@ -156,7 +156,7 @@ The following arguments are supported:
       * `last_name` - (Required) The last name of the technical contact at Akamai.
       * `title` - (Optional) The title of the technical contact at Akamai.
       * `organization` - (Required) The name of the organization in Akamai where your technical contact works.
-      * `email` - (Required) The email address of the technical contact at Akamai. This must include the `@akamai.com` domain.
+      * `email` - (Required) The email address of the technical contact at Akamai, accessible at the `akamai.com` domain.
       * `phone` - (Required) The phone number of the technical contact at Akamai.
       * `address_line_one` - (Required) The address for the technical contact at Akamai.
       * `address_line_two` - (Optional) The address for the technical contact at Akamai.

--- a/docs/resources/cps_dv_enrollment.md
+++ b/docs/resources/cps_dv_enrollment.md
@@ -96,7 +96,7 @@ output "enrollment_id" {
 
 The following arguments are supported:
 
-* `contract_id` - (Required) A contract's unique ID, optionally with the `ctr_` prefix.
+* `contract_id` - (Required) A contract's ID, optionally with the `ctr_` prefix.
 * `common_name` - (Required) The fully qualified domain name (FQDN) for which you plan to use your certificate. The domain name you specify here must be owned or have legal rights to use the domain by the company you specify as `organization`. The company that owns the domain name must be a legally incorporated entity and be active and in good standing.
 * `sans` - (Optional) Additional common names to create a Subject Alternative Names (SAN) list.
 * `secure_network` - (Required) The type of deployment network you want to use. `standard-tls` deploys your certificate to Akamai’s standard secure network, but it isn't PCI compliant. `enhanced-tls` deploys your certificate to Akamai’s more secure network with PCI compliance capability.

--- a/docs/resources/cps_dv_enrollment.md
+++ b/docs/resources/cps_dv_enrollment.md
@@ -64,8 +64,8 @@ resource "akamai_cps_dv_enrollment" "example" {
     clone_dns_names = false
     geography = "core"
     ocsp_stapling = "on"
-    preferred_ciphers = "ak-akamai-default"
-    must_have_ciphers = "ak-akamai-default"
+    preferred_ciphers = "ak-akamai-2020q1"
+    must_have_ciphers = "ak-akamai-2020q1"
     quic_enabled = false
   }
   signature_algorithm = "SHA-256"
@@ -81,15 +81,15 @@ resource "akamai_cps_dv_enrollment" "example" {
 }
 
 output "dns_challenges" {
-  value = akamai_cps_dv_enrollment.dv.dns_challenges
+  value = akamai_cps_dv_enrollment.example.dns_challenges
 }
 
 output "http_challenges" {
-  value = akamai_cps_dv_enrollment.dv.http_challenges
+  value = akamai_cps_dv_enrollment.example.http_challenges
 }
 
 output "enrollment_id" {
-  value = akamai_cps_dv_enrollment.dv.id
+  value = akamai_cps_dv_enrollment.example.id
 }
 ```
 ## Argument reference
@@ -99,7 +99,7 @@ The following arguments are supported:
 * `contract_id` - (Required) A contract's unique ID, without the `ctr_` prefix.
 * `common_name` - (Required) The fully qualified domain name (FQDN) for which you plan to use your certificate. The domain name you specify here must be owned or have legal rights to use the domain by the company you specify as `organization`. The company that owns the domain name must be a legally incorporated entity and be active and in good standing.
 * `sans` - (Optional) Additional common names to create a Subject Alternative Names (SAN) list.
-* `secure_network` - (Required) The type of deployment network you want to use. `Standard TLS` deploys your certificate to Akamai’s standard secure network, but it isn't PCI compliant. `Enhanced TLS` deploys your certificate to Akamai’s more secure network with PCI compliance capability.
+* `secure_network` - (Required) The type of deployment network you want to use. `standard-tls` deploys your certificate to Akamai’s standard secure network, but it isn't PCI compliant. `enhanced-tls` deploys your certificate to Akamai’s more secure network with PCI compliance capability.
 * `sni_only` - (Required) Whether you want to enable SNI-only extension for the enrollment. Server Name Indication (SNI) is an extension of the Transport Layer Security (TLS) networking protocol. It allows a server to present multiple certificates on the same IP address. All modern web browsers support the SNI extension. If you have the same SAN on two or more certificates with the SNI-only option set, Akamai may serve traffic using any certificate which matches the requested SNI hostname. You should avoid multiple certificates with overlapping SAN names when using SNI-only. You can't change this setting once an enrollment is created.
 * `acknowledge_pre_verification_warnings` - (Optional) Whether you want to automatically acknowledge the validation warnings of the current job state and proceed with the execution of a change.
 * `admin_contact` - (Required) Contact information for the certificate administrator at your company.
@@ -156,7 +156,7 @@ The following arguments are supported:
       * `last_name` - (Required) The last name of the technical contact at Akamai.
       * `title` - (Optional) The title of the technical contact at Akamai.
       * `organization` - (Required) The name of the organization in Akamai where your technical contact works.
-      * `email` - (Required) The email address of the technical contact at Akamai.
+      * `email` - (Required) The email address of the technical contact at Akamai. This must include the `@akamai.com` domain.
       * `phone` - (Required) The phone number of the technical contact at Akamai.
       * `address_line_one` - (Required) The address for the technical contact at Akamai.
       * `address_line_two` - (Optional) The address for the technical contact at Akamai.

--- a/docs/resources/cps_dv_validation.md
+++ b/docs/resources/cps_dv_validation.md
@@ -16,7 +16,8 @@ Basic usage:
 
 ```hcl
 resource "akamai_cps_dv_validation" "example" {
-  enrollment_id = akamai_cps_dv_enrollment.dv.id
+  enrollment_id = akamai_cps_dv_enrollment.example.id
+}
 ```
 ## Argument reference
 

--- a/docs/resources/cps_dv_validation.md
+++ b/docs/resources/cps_dv_validation.md
@@ -17,6 +17,7 @@ Basic usage:
 ```hcl
 resource "akamai_cps_dv_validation" "example" {
   enrollment_id = akamai_cps_dv_enrollment.example.id
+  sans = akamai_cps_dv_enrollment.example.sans
 }
 ```
 ## Argument reference
@@ -24,6 +25,7 @@ resource "akamai_cps_dv_validation" "example" {
 The following arguments are supported:
 
 * `enrollment_id` (Required) - Unique identifier for the DV certificate enrollment.
+* `sans` - (Optional) The Subject Alternative Names (SAN) list for tracking changes on related enrollments. Whenever any SAN changes, the Akamai provider recreates this resource and sends another acknowledgement request to CPS.
 
 ## Attributes reference
 

--- a/docs/resources/dns_zone.md
+++ b/docs/resources/dns_zone.md
@@ -47,3 +47,7 @@ This resource supports these arguments:
     * `algorithm` - The hashing algorithm.
     * `secret` - String known between transfer endpoints.
 * `end_customer_id` - (Optional) A free form identifier for the zone.
+
+## Zone Import Note
+
+The provider zone resource import does not have access to the resource configuration during import processing. As such, the contract argument will be populated in the terraform zone resource state after the import but the group attribute will not. Executing a `terraform apply` will reconcile the configuration and the terraform zone resource state.

--- a/docs/resources/dns_zone.md
+++ b/docs/resources/dns_zone.md
@@ -35,7 +35,7 @@ This resource supports these arguments:
 
 * `comment` - (Required) A descriptive comment.
 * `contract` - (Required) The contract ID.
-* `group` - (Required) The currently selected group ID.
+* `group` - (Optional) The currently selected group ID.
 * `zone` - (Required) The domain zone, encapsulating any nested subdomains.
 * `type` - (Required) Whether the zone is `primary`, `secondary`, or `alias`.
 * `masters` - (Required for `secondary` zones) The names or IP addresses of the nameservers that the zone data should be retrieved from.

--- a/docs/resources/edge_hostname.md
+++ b/docs/resources/edge_hostname.md
@@ -1,26 +1,26 @@
 ---
 layout: "akamai"
 page_title: "Akamai: edge hostname"
-subcategory: "Provisioning"
+subcategory: "Property Provisioning"
 description: |-
   Edge Hostname
 ---
 
 # akamai_edge_hostname
 
-~> **Note** Version 1.0.0 of the Akamai Terraform Provider is now available for the Property Provisioning module. To upgrade to the new version, you have to update this resource. See the [upgrade guide](../guides/1.0_migration.md) for details. 
+~> **Note** Version 1.0.0 of the Akamai Terraform Provider is now available for the Property Provisioning module. To upgrade to the new version, you have to update this resource. See the [upgrade guide](../guides/1.0_migration.md) for details.
 
-The `akamai_edge_hostname` resource lets you configure a secure edge hostname. Your 
-edge hostname determines how requests for your site, app, or content are mapped to 
-Akamai edge servers. 
+The `akamai_edge_hostname` resource lets you configure a secure edge hostname. Your
+edge hostname determines how requests for your site, app, or content are mapped to
+Akamai edge servers.
 
-An edge hostname is the CNAME target you use when directing your end user traffic to 
-Akamai. Each hostname assigned to a property has a corresponding edge hostname. 
- 
-Akamai supports three types of edge hostnames, depending on the level of security 
-you need for your traffic: Standard TLS, Enhanced TLS, and Shared Certificate. When 
-entering the `edge_hostname` attribute, you need to include a specific domain suffix 
-for your edge hostname type: 
+An edge hostname is the CNAME target you use when directing your end user traffic to
+Akamai. Each hostname assigned to a property has a corresponding edge hostname.
+
+Akamai supports three types of edge hostnames, depending on the level of security
+you need for your traffic: Standard TLS, Enhanced TLS, and Shared Certificate. When
+entering the `edge_hostname` attribute, you need to include a specific domain suffix
+for your edge hostname type:
 
 | Edge hostname type | Domain suffix |
 |------|-------|
@@ -48,7 +48,7 @@ resource "akamai_edge_hostname" "terraform-demo" {
 This resource supports these arguments:
 
 * `name` - (Required) The name of the edge hostname.
-* `contract_id` - (Required) A contract's unique ID, including the `ctr_` prefix. 
+* `contract_id` - (Required) A contract's unique ID, including the `ctr_` prefix.
 * `group_id` - (Required) A group's unique ID, including the `grp_` prefix.
 * `product_id` - (Required) A product's unique ID, including the `prd_` prefix.
 * `edge_hostname` - (Required) One or more edge hostnames. The number of edge hostnames must be less than or equal to the number of public hostnames.
@@ -77,10 +77,10 @@ resource "akamai_edge_hostname" "example" {
   }
 ```
 
-You can import Akamai edge hostnames using a comma-delimited string of edge 
-hostname, contract ID, and group ID. You have to enter the values in this order: 
+You can import Akamai edge hostnames using a comma-delimited string of edge
+hostname, contract ID, and group ID. You have to enter the values in this order:
 
- `edge_hostname, contract_id, group_id` 
+ `edge_hostname, contract_id, group_id`
 
 For example:
 

--- a/docs/resources/gtm_property.md
+++ b/docs/resources/gtm_property.md
@@ -8,7 +8,7 @@ description: |-
 
 # akamai_gtm_property
 
-Use the `akamai_gtm_property` resource provides the resource for creating, configuring and importing a GTM property, a set of IP addresses or CNAMEs that GTM provides in response to DNS queries based on a set of rules. 
+Use the `akamai_gtm_property` resource to create, configure and import a GTM property, a set of IP addresses or CNAMEs that GTM provides in response to DNS queries based on a set of rules.
 
 ~> **Note** Import requires an ID with this format: `existing_domain_name`:`existing_property_name`.
 
@@ -35,30 +35,30 @@ resource "akamai_gtm_property" "demo_property" {
 This resource supports these arguments:
 
 * `domain` - (Required) DNS name for the GTM Domain set that includes this Property.
-* `name` - (Required) DNS name for a collection of IP address or CNAME responses. The value, together with the GTM domainName, forms the Property’s hostname. 
-* `type` - (Required) Specifies the load balancing behavior for the property. Either failover, geographic, cidrmapping, weighted-round-robin, weighted-hashed, weighted-round-robin-load-feedback, qtr, or performance. 
+* `name` - (Required) DNS name for a collection of IP address or CNAME responses. The value, together with the GTM domainName, forms the Property’s hostname.
+* `type` - (Required) Specifies the load balancing behavior for the property. Either failover, geographic, cidrmapping, weighted-round-robin, weighted-hashed, weighted-round-robin-load-feedback, qtr, or performance.
 * `score_aggregation_type` - (Required) Specifies how GTM aggregates liveness test scores across different tests, when multiple tests are configured.
 * `handout_limit` - (Required) Indicates the limit for the number of live IPs handed out to a DNS request.
 * `handout_mode` - (Required) Specifies how IPs are returned when more than one IP is alive and available.
-* `traffic_target` - (Required) Contains information about where to direct data center traffic. You can have multiple `traffic_target` arguments. If used, requires these arguments:
-  * `datacenter_id` - (Required) A unique identifier for an existing data center in the domain.
-  * `enabled` - (Required) A boolean indicating whether the traffic target is used. You can also omit the traffic target, which has the same result as the false value.
-  * `weight` - (Required) Specifies the traffic weight for the target.
-  * `servers` - (Required) (List) Identifies the IP address or the hostnames of the servers.
-  * `name` - (Required) An alternative label for the traffic target.
-  * `handout_cname` - (Required) Specifies an optional data center for the property. Used when there are no servers configured for the property.
+* `traffic_target` - (Optional) Contains information about where to direct data center traffic. You can have multiple `traffic_target` arguments. If used, includes these arguments:
+  * `datacenter_id` - (Optional) A unique identifier for an existing data center in the domain.
+  * `enabled` - (Optional) A boolean indicating whether the traffic target is used. You can also omit the traffic target, which has the same result as the false value.
+  * `weight` - (Optional) Specifies the traffic weight for the target.
+  * `servers` - (Optional) (List) Identifies the IP address or the hostnames of the servers.
+  * `name` - (Optional) An alternative label for the traffic target.
+  * `handout_cname` - (Optional) Specifies an optional data center for the property. Used when there are no servers configured for the property.
 * `liveness_test` - (Optional) Contains information about the liveness tests, which are run periodically to determine whether your servers respond to requests. You can have multiple `liveness_test` arguments. If used, requires these arguments:
-  * `name` - (Optional) A descriptive name for the liveness test.
-  * `test_interval` - (Optional) Indicates the interval at which the liveness test is run, in seconds. Requires a minimum of 10 seconds.
-  * `test_object_protocol` - (Optional) Specifies the test protocol. Possible values include `DNS`, `HTTP`, `HTTPS`, `FTP`, `POP`, `POPS`, `SMTP`, `SMTPS`, `TCP`, or `TCPS`.
-  * `test_timeout` - (Optional) Specifies the duration of the liveness test before it fails. The range is from 0.001 to 60 seconds.
+  * `name` - (Required) A descriptive name for the liveness test.
+  * `test_interval` - (Required) Indicates the interval at which the liveness test is run, in seconds. Requires a minimum of 10 seconds.
+  * `test_object_protocol` - (Required) Specifies the test protocol. Possible values include `DNS`, `HTTP`, `HTTPS`, `FTP`, `POP`, `POPS`, `SMTP`, `SMTPS`, `TCP`, or `TCPS`.
+  * `test_timeout` - (Required) Specifies the duration of the liveness test before it fails. The range is from 0.001 to 60 seconds.
   * `answers_required` - (Optional) If `test_object_protocol` is DNS, enter a boolean value if an answer is needed for the DNS query to be successful.
   * `disabled` - (Optional) A boolean indicating whether the liveness test is disabled. When disabled, GTM stops running the test, effectively treating it as if it no longer exists.
   * `disable_nonstandard_port_warning` - (Optional) A boolean that if set to `true`, disables warnings when non-standard ports are used.
   * `error_penalty` - (Optional) Specifies the score that’s reported if the liveness test encounters an error other than timeout, such as connection refused, and 404.
-  * `http_header` - (Optional) Contains HTTP headers to send if the `test_object_protocol` is `http` or `https`. You can have multiple `http_header` entries. Requires these arguments: 
-    * `name` - Name of HTTP header.
-    * `value` - Value of HTTP header.
+  * `http_header` - (Optional) Contains HTTP headers to send if the `test_object_protocol` is `http` or `https`. You can have multiple `http_header` entries. Requires these arguments:
+    * `name` - (Optional) Name of HTTP header.
+    * `value` - (Optional) Value of HTTP header.
   * `http_error3xx` - (Optional) A boolean that if set to `true`, treats a 3xx HTTP response as a failure if the `test_object_protocol` is `http`, `https`, or `ftp`.
   * `http_error4xx` - (Optional) A boolean that if set to `true`, treats a 4xx HTTP response as a failure if the `test_object_protocol` is `http`, `https`, or `ftp`.
   * `http_error5xx` - (Optional) A boolean that if set to `true`, treats a 5xx HTTP response as a failure if the `test_object_protocol` is `http`, `https`, or `ftp`.
@@ -69,9 +69,9 @@ This resource supports these arguments:
   * `response_string` - (Optional) Specifies a response string.
   * `ssl_client_certificate` - (Optional) Indicates a Base64-encoded certificate. SSL client certificates are available for livenessTests that use secure protocols.
   * `ssl_client_private_key` - (Optional) Indicates a Base64-encoded private key. The private key used to generate or request a certificate for livenessTests can’t have a passphrase nor be used for any other purpose.
-  * `test_object` - (Optional) Specifies the static text that acts as a stand-in for the data that you’re sending on the network.
+  * `test_object` - (Required) Specifies the static text that acts as a stand-in for the data that you’re sending on the network.
   * `test_object_password` - (Optional) Specifies the test object’s password. It is required if testObjectProtocol is ftp.
-  * `test_object_port` - (Optional) Specifies the port number for the testObject.
+  * `test_object_port` - (Required) Specifies the port number for the testObject.
   * `test_object_username` - (Optional) A descriptive name for the testObject.
   * `timeout_penalty`- (Optional) Specifies the score to be reported if the liveness test times out.
 * `wait_on_complete` - (Optional) A boolean indicating whether to wait for transaction to complete. Set to `true` by default.
@@ -82,7 +82,8 @@ This resource supports these arguments:
 * `stickiness_bonus_constant` - (Optional) Specifies a constant used to configure data center affinity.
 * `health_threshold` - (Optional) Configures a cutoff value that is computed from the median scores.
 * `use_computed_targets` - (Optional) For load-feedback domains only, a boolean that indicates whether you want GTM to automatically compute target load.
-* `backup_ip` - Specifies a backup IP. When GTM declares that all of the targets are down, the backupIP is handed out.
+* `backup_ip` - (Optional) Specifies a backup IP. When GTM declares that all of the targets are down, the backup IP is handed out. If a backup IP is set, do not set a backup CNAME.
+* `backup_cname` - (Optional) Specifies a backup CNAME. If GTM declares that all of the servers configured for your property are down, the backup CNAME is handed out. If a backup CNAME is set, do not set a backup IP.
 * `balance_by_download_score` - (Optional) A boolean that indicates whether download score based load balancing is enabled.
 * `unreachable_threshold` - (Optional) For performance domains, this specifies a penalty value that’s added to liveness test scores when data centers have an aggregated loss fraction higher than this value.
 * `health_multiplier` - (Optional) Configures a cutoff value that is computed from the median scores.
@@ -95,7 +96,7 @@ This resource supports these arguments:
 * `comments` - (Optional) A descriptive note about changes to the domain. The maximum is 4000 characters.
 * `ghost_demand_reporting` - (Optional) Use load estimates from Akamai Ghost utilization messages.
 * `min_live_fraction` - (Optional) Specifies what fraction of the servers need to respond to requests so GTM considers the data center up and able to receive traffic.
-* `static_rr_set` - (Optional) Contains static record sets. You can have multiple `static_rr_set` entries. Requires these arguments: 
+* `static_rr_set` - (Optional) Contains static record sets. You can have multiple `static_rr_set` entries. Requires these arguments:
   * `type` - (Optional) The record type.
   * `ttl` - (Optional) The number of seconds that this record should live in a resolver’s cache before being refetched.
   * `rdata` - (Optional) (List) An array of data strings, representing multiple records within a set.

--- a/docs/resources/property.md
+++ b/docs/resources/property.md
@@ -1,7 +1,7 @@
 ---
 layout: "akamai"
 page_title: "Akamai: property"
-subcategory: "Provisioning"
+subcategory: "Property Provisioning"
 description: |-
   Create and update Akamai properties.
 ---

--- a/docs/resources/property_activation.md
+++ b/docs/resources/property_activation.md
@@ -1,7 +1,7 @@
 ---
 layout: "akamai"
 page_title: "Akamai: property activation"
-subcategory: "Provisioning"
+subcategory: "Property Provisioning"
 description: |-
   Property Activation
 ---

--- a/pkg/providers/cps/resource_akamai_cps_dv_enrollment.go
+++ b/pkg/providers/cps/resource_akamai_cps_dv_enrollment.go
@@ -226,7 +226,7 @@ func resourceCPSDVEnrollment() *schema.Resource {
 				Type:             schema.TypeString,
 				ForceNew:         true,
 				Required:         true,
-				DiffSuppressFunc: diffSuppressContractId,
+				DiffSuppressFunc: diffSuppressContractID,
 			},
 			"certificate_type": {
 				Type:     schema.TypeString,
@@ -445,7 +445,7 @@ func resourceCPSDVEnrollmentCreate(ctx context.Context, d *schema.ResourceData, 
 
 	req := cps.CreateEnrollmentRequest{
 		Enrollment: enrollment,
-		ContractID: tools.TrimPrefix(contractID, "ctr_"),
+		ContractID: strings.TrimPrefix(contractID, "ctr_"),
 	}
 	res, err := client.CreateEnrollment(ctx, req)
 	if err != nil {
@@ -820,11 +820,11 @@ func resourceCPSDVEnrollmentImport(ctx context.Context, d *schema.ResourceData, 
 	return []*schema.ResourceData{d}, nil
 }
 
-func diffSuppressContractId(k string, old string, new string, d *schema.ResourceData) bool {
-	trimPrefixFromOld := tools.TrimPrefix(old, "ctr_")
-	trimPrefixFromNew := tools.TrimPrefix(new, "ctr_")
+func diffSuppressContractID(k, old, new string, d *schema.ResourceData) bool {
+	trimPrefixFromOld := strings.TrimPrefix(old, "ctr_")
+	trimPrefixFromNew := strings.TrimPrefix(new, "ctr_")
 
-	if old == new || trimPrefixFromOld == trimPrefixFromNew {
+	if trimPrefixFromOld == trimPrefixFromNew {
 		return true
 	}
 	return false

--- a/pkg/providers/cps/resource_akamai_cps_dv_enrollment.go
+++ b/pkg/providers/cps/resource_akamai_cps_dv_enrollment.go
@@ -540,6 +540,12 @@ func resourceCPSDVEnrollmentRead(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	if len(status.AllowedInput) < 1 || status.AllowedInput[0].Type != "lets-encrypt-challenges" {
+		if err := d.Set("http_challenges", httpChallenges); err != nil {
+			return diag.Errorf("%v: %s", tools.ErrValueSet, err.Error())
+		}
+		if err := d.Set("dns_challenges", schema.NewSet(cpstools.HashFromChallengesMap, dnsChallenges)); err != nil {
+			return diag.Errorf("%v: %s", tools.ErrValueSet, err.Error())
+		}
 		return nil
 	}
 	getChallengesReq := cps.GetChangeRequest{
@@ -737,7 +743,7 @@ func waitForVerification(ctx context.Context, logger log.Interface, client cps.C
 	changeID, err := cpstools.GetChangeIDFromPendingChanges(enrollmentGet.PendingChanges)
 	if err != nil {
 		if errors.Is(err, cpstools.ErrNoPendingChanges) {
-			logger.Debug("No pending changes found on the enrollmentl")
+			logger.Debug("No pending changes found on the enrollment")
 			return nil
 		}
 		return err

--- a/pkg/providers/cps/resource_akamai_cps_dv_enrollment.go
+++ b/pkg/providers/cps/resource_akamai_cps_dv_enrollment.go
@@ -223,9 +223,10 @@ func resourceCPSDVEnrollment() *schema.Resource {
 				},
 			},
 			"contract_id": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Required: true,
+				Type:             schema.TypeString,
+				ForceNew:         true,
+				Required:         true,
+				DiffSuppressFunc: diffSuppressContractId,
 			},
 			"certificate_type": {
 				Type:     schema.TypeString,
@@ -444,7 +445,7 @@ func resourceCPSDVEnrollmentCreate(ctx context.Context, d *schema.ResourceData, 
 
 	req := cps.CreateEnrollmentRequest{
 		Enrollment: enrollment,
-		ContractID: contractID,
+		ContractID: tools.TrimPrefix(contractID, "ctr_"),
 	}
 	res, err := client.CreateEnrollment(ctx, req)
 	if err != nil {
@@ -817,4 +818,14 @@ func resourceCPSDVEnrollmentImport(ctx context.Context, d *schema.ResourceData, 
 	}
 	d.SetId(enrollmentID)
 	return []*schema.ResourceData{d}, nil
+}
+
+func diffSuppressContractId(k string, old string, new string, d *schema.ResourceData) bool {
+	trimPrefixFromOld := tools.TrimPrefix(old, "ctr_")
+	trimPrefixFromNew := tools.TrimPrefix(new, "ctr_")
+
+	if old == new || trimPrefixFromOld == trimPrefixFromNew {
+		return true
+	}
+	return false
 }

--- a/pkg/providers/cps/resource_akamai_cps_dv_enrollment_test.go
+++ b/pkg/providers/cps/resource_akamai_cps_dv_enrollment_test.go
@@ -88,7 +88,7 @@ func TestResourceDVEnrollment(t *testing.T) {
 			mock.Anything,
 			cps.CreateEnrollmentRequest{
 				Enrollment: enrollment,
-				ContractID: "ctr_1",
+				ContractID: "1",
 			},
 		).Return(&cps.CreateEnrollmentResponse{
 			ID:         1,
@@ -333,7 +333,7 @@ func TestResourceDVEnrollment(t *testing.T) {
 			mock.Anything,
 			cps.CreateEnrollmentRequest{
 				Enrollment: enrollment,
-				ContractID: "ctr_1",
+				ContractID: "1",
 			},
 		).Return(&cps.CreateEnrollmentResponse{
 			ID:         1,
@@ -549,7 +549,7 @@ func TestResourceDVEnrollment(t *testing.T) {
 			mock.Anything,
 			cps.CreateEnrollmentRequest{
 				Enrollment: enrollment,
-				ContractID: "ctr_1",
+				ContractID: "1",
 			},
 		).Return(&cps.CreateEnrollmentResponse{
 			ID:         1,
@@ -715,7 +715,7 @@ func TestResourceDVEnrollment(t *testing.T) {
 			mock.Anything,
 			cps.CreateEnrollmentRequest{
 				Enrollment: enrollment,
-				ContractID: "ctr_1",
+				ContractID: "1",
 			},
 		).Return(&cps.CreateEnrollmentResponse{
 			ID:         1,
@@ -831,7 +831,7 @@ func TestResourceDVEnrollment(t *testing.T) {
 			mock.Anything,
 			cps.CreateEnrollmentRequest{
 				Enrollment: enrollment,
-				ContractID: "ctr_1",
+				ContractID: "1",
 			},
 		).Return(nil, fmt.Errorf("error creating enrollment")).Once()
 
@@ -915,7 +915,7 @@ func TestResourceDVEnrollmentImport(t *testing.T) {
 		mock.Anything,
 		cps.CreateEnrollmentRequest{
 			Enrollment: enrollment,
-			ContractID: "ctr_1",
+			ContractID: "1",
 		},
 	).Return(&cps.CreateEnrollmentResponse{
 		ID:         1,

--- a/pkg/providers/cps/resource_akamai_cps_dv_enrollment_test.go
+++ b/pkg/providers/cps/resource_akamai_cps_dv_enrollment_test.go
@@ -1006,3 +1006,23 @@ func TestResourceDVEnrollmentImport(t *testing.T) {
 		})
 	})
 }
+
+func TestDiffSuppressContractId(t *testing.T) {
+	tests := map[string]struct {
+		oldContractId, newContractId string
+		expected                     bool
+	}{
+		"1": {"", "", true},
+		"2": {"test", "test", true},
+		"3": {"ctr_test", "test", true},
+		"4": {"test", "ctr_test", true},
+		"5": {"test", "", false},
+		"6": {"", "test", false},
+		"7": {"ctr_test", "_test", false},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expected, diffSuppressContractId("", test.oldContractId, test.newContractId, nil))
+		})
+	}
+}

--- a/pkg/providers/cps/resource_akamai_cps_dv_enrollment_test.go
+++ b/pkg/providers/cps/resource_akamai_cps_dv_enrollment_test.go
@@ -270,6 +270,146 @@ func TestResourceDVEnrollment(t *testing.T) {
 		client.AssertExpectations(t)
 	})
 
+	t.Run("set challenges arrays to empty if no allowedInput found", func(t *testing.T) {
+		client := &mockcps{}
+		enrollment := cps.Enrollment{
+			AdminContact: &cps.Contact{
+				AddressLineOne:   "150 Broadway",
+				City:             "Cambridge",
+				Country:          "US",
+				Email:            "r1d1@akamai.com",
+				FirstName:        "R1",
+				LastName:         "D1",
+				OrganizationName: "Akamai",
+				Phone:            "123123123",
+				PostalCode:       "12345",
+				Region:           "MA",
+			},
+			CertificateChainType: "default",
+			CertificateType:      "san",
+			ChangeManagement:     false,
+			CSR: &cps.CSR{
+				C:    "US",
+				CN:   "test.akamai.com",
+				L:    "Cambridge",
+				O:    "Akamai",
+				OU:   "WebEx",
+				SANS: []string{"san.test.akamai.com"},
+				ST:   "MA",
+			},
+			EnableMultiStackedCertificates: false,
+			NetworkConfiguration: &cps.NetworkConfiguration{
+				DisallowedTLSVersions: []string{"TLSv1", "TLSv1_1"},
+				DNSNameSettings: &cps.DNSNameSettings{
+					CloneDNSNames: false,
+					DNSNames:      []string{"san.test.akamai.com"},
+				},
+				Geography:        "core",
+				MustHaveCiphers:  "ak-akamai-default",
+				OCSPStapling:     "on",
+				PreferredCiphers: "ak-akamai-default",
+				QuicEnabled:      false,
+				SecureNetwork:    "enhanced-tls",
+				SNIOnly:          true,
+			},
+			Org: &cps.Org{
+				AddressLineOne: "150 Broadway",
+				City:           "Cambridge",
+				Country:        "US",
+				Name:           "Akamai",
+				Phone:          "321321321",
+				PostalCode:     "12345",
+				Region:         "MA",
+			},
+			RA:                 "lets-encrypt",
+			SignatureAlgorithm: "SHA-256",
+			TechContact: &cps.Contact{
+				AddressLineOne:   "150 Broadway",
+				City:             "Cambridge",
+				Country:          "US",
+				Email:            "r2d2@akamai.com",
+				FirstName:        "R2",
+				LastName:         "D2",
+				OrganizationName: "Akamai",
+				Phone:            "123123123",
+				PostalCode:       "12345",
+				Region:           "MA",
+			},
+			ValidationType: "dv",
+		}
+
+		client.On("CreateEnrollment",
+			mock.Anything,
+			cps.CreateEnrollmentRequest{
+				Enrollment: enrollment,
+				ContractID: "1",
+			},
+		).Return(&cps.CreateEnrollmentResponse{
+			ID:         1,
+			Enrollment: "/cps/v2/enrollments/1",
+			Changes:    []string{"/cps/v2/enrollments/1/changes/2"},
+		}, nil).Once()
+
+		enrollment.Location = "/cps/v2/enrollments/1"
+		enrollment.PendingChanges = []string{"/cps/v2/enrollments/1/changes/2"}
+		client.On("GetEnrollment", mock.Anything, cps.GetEnrollmentRequest{EnrollmentID: 1}).
+			Return(&enrollment, nil).Once()
+
+		client.On("GetChangeStatus", mock.Anything, cps.GetChangeStatusRequest{
+			EnrollmentID: 1,
+			ChangeID:     2,
+		}).Return(&cps.Change{
+			AllowedInput: []cps.AllowedInput{},
+			StatusInfo: &cps.StatusInfo{
+				State:  "awaiting-input",
+				Status: "coodinate-domain-validation",
+			},
+		}, nil).Once()
+
+		client.On("GetEnrollment", mock.Anything, cps.GetEnrollmentRequest{EnrollmentID: 1}).
+			Return(&enrollment, nil).Times(2)
+
+		client.On("GetChangeStatus", mock.Anything, cps.GetChangeStatusRequest{
+			EnrollmentID: 1,
+			ChangeID:     2,
+		}).Return(&cps.Change{
+			AllowedInput: []cps.AllowedInput{},
+			StatusInfo: &cps.StatusInfo{
+				State:  "awaiting-input",
+				Status: "coodinate-domain-validation",
+			},
+		}, nil).Times(2)
+
+		allowCancel := true
+		client.On("RemoveEnrollment", mock.Anything, cps.RemoveEnrollmentRequest{
+			EnrollmentID:              1,
+			AllowCancelPendingChanges: &allowCancel,
+		}).Return(&cps.RemoveEnrollmentResponse{
+			Enrollment: "1",
+		}, nil)
+
+		useClient(client, func() {
+			resource.UnitTest(t, resource.TestCase{
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: loadFixtureString("testdata/TestResDVEnrollment/lifecycle/create_enrollment.tf"),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestCheckResourceAttr("akamai_cps_dv_enrollment.dv", "contract_id", "ctr_1"),
+							resource.TestCheckResourceAttr("akamai_cps_dv_enrollment.dv", "certificate_type", "san"),
+							resource.TestCheckResourceAttr("akamai_cps_dv_enrollment.dv", "validation_type", "dv"),
+							resource.TestCheckResourceAttr("akamai_cps_dv_enrollment.dv", "registration_authority", "lets-encrypt"),
+							resource.TestCheckResourceAttr("akamai_cps_dv_enrollment.dv", "dns_challenges.#", "0"),
+							resource.TestCheckResourceAttr("akamai_cps_dv_enrollment.dv", "http_challenges.#", "0"),
+						),
+					},
+				},
+			})
+		})
+
+		client.AssertExpectations(t)
+	})
+
 	t.Run("update with acknowledge warnings change, no enrollment update", func(t *testing.T) {
 		client := &mockcps{}
 		enrollment := cps.Enrollment{

--- a/pkg/providers/cps/resource_akamai_cps_dv_enrollment_test.go
+++ b/pkg/providers/cps/resource_akamai_cps_dv_enrollment_test.go
@@ -1007,9 +1007,9 @@ func TestResourceDVEnrollmentImport(t *testing.T) {
 	})
 }
 
-func TestDiffSuppressContractId(t *testing.T) {
+func TestDiffSuppressContractID(t *testing.T) {
 	tests := map[string]struct {
-		oldContractId, newContractId string
+		oldContractID, newContractID string
 		expected                     bool
 	}{
 		"1": {"", "", true},
@@ -1022,7 +1022,7 @@ func TestDiffSuppressContractId(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, test.expected, diffSuppressContractId("", test.oldContractId, test.newContractId, nil))
+			assert.Equal(t, test.expected, diffSuppressContractID("", test.oldContractID, test.newContractID, nil))
 		})
 	}
 }

--- a/pkg/providers/cps/resource_akamai_cps_dv_validation.go
+++ b/pkg/providers/cps/resource_akamai_cps_dv_validation.go
@@ -35,6 +35,12 @@ func resourceCPSDVValidation() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"sans": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+				ForceNew: true,
+			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/pkg/providers/cps/testdata/TestResDVValidation/update_validation.tf
+++ b/pkg/providers/cps/testdata/TestResDVValidation/update_validation.tf
@@ -6,5 +6,6 @@ resource "akamai_cps_dv_validation" "dv_validation" {
   enrollment_id = 1
   sans = [
     "san.test.akamai.com",
+    "san2.test.akamai.com",
   ]
 }

--- a/pkg/providers/dns/resource_akamai_dns_zone.go
+++ b/pkg/providers/dns/resource_akamai_dns_zone.go
@@ -60,7 +60,7 @@ func resourceDNSv2Zone() *schema.Resource {
 			},
 			"group": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"sign_and_serve": {
 				Type:     schema.TypeBool,
@@ -473,6 +473,9 @@ func validateZoneType(v interface{}, _ string) (ws []string, es []error) {
 // populate zone state based on API response.
 func populateDNSv2ZoneState(d *schema.ResourceData, zoneresp *dns.ZoneResponse) error {
 
+	if err := d.Set("contract", zoneresp.ContractID); err != nil {
+		return fmt.Errorf("%w: %s", tools.ErrValueSet, err.Error())
+	}
 	if err := d.Set("masters", zoneresp.Masters); err != nil {
 		return fmt.Errorf("%w: %s", tools.ErrValueSet, err.Error())
 	}

--- a/pkg/providers/dns/resource_akamai_dns_zone_test.go
+++ b/pkg/providers/dns/resource_akamai_dns_zone_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestResDnsZone(t *testing.T) {
 	zone := &dns.ZoneResponse{
-		ContractID:      "ctr2",
+		ContractID:      "ctr1",
 		Zone:            "primaryexampleterraform.io",
 		Type:            "primary",
 		Comment:         "This is a test primary zone",

--- a/pkg/providers/property/diff_suppress_funcs.go
+++ b/pkg/providers/property/diff_suppress_funcs.go
@@ -8,6 +8,9 @@ import (
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v2/pkg/papi"
 )
 
+// compareRulesJSON handles comparison between two papi.Rules JSON representations
+// true: deeply equals
+// false: not deeply equals
 func compareRulesJSON(old, new string) bool {
 	var oldRules, newRules papi.GetRuleTreeResponse
 	if old == new {
@@ -33,6 +36,8 @@ func compareRuleTree(old, new *papi.RulesUpdate) bool {
 
 // compareRules handles comparison between two papi.Rules objects
 // due to an issue in PAPI we need to compare collections of behaviors, criteria and variables discarding the order from JSON
+// true: deeply equals
+// false: not deeply equals
 func compareRules(old, new *papi.Rules) bool {
 	if len(old.Behaviors) != len(new.Behaviors) ||
 		len(old.Criteria) != len(new.Criteria) ||

--- a/pkg/providers/property/papi_test.go
+++ b/pkg/providers/property/papi_test.go
@@ -231,6 +231,22 @@ func (p *mockpapi) GetPropertyVersions(ctx context.Context, r papi.GetPropertyVe
 	return args.Get(0).(*papi.GetPropertyVersionsResponse), args.Error(1)
 }
 
+type GetPropertyVersionsFunc func(context.Context, papi.GetPropertyVersionsRequest) (*papi.GetPropertyVersionsResponse, error)
+
+// Expect a call to the mock's papi.GetPropertyVersions() where the return value is computed by the given
+// function
+func (p *mockpapi) OnGetPropertyVersions(ctx, req interface{}, impl GetPropertyVersionsFunc) *mock.Call {
+	call := p.On("GetPropertyVersions", ctx, req)
+	call.Run(func(CallArgs mock.Arguments) {
+		callCtx := CallArgs.Get(0).(context.Context)
+		callReq := CallArgs.Get(1).(papi.GetPropertyVersionsRequest)
+
+		call.Return(impl(callCtx, callReq))
+	})
+
+	return call
+}
+
 func (p *mockpapi) GetPropertyVersion(ctx context.Context, r papi.GetPropertyVersionRequest) (*papi.GetPropertyVersionsResponse, error) {
 	args := p.Called(ctx, r)
 

--- a/pkg/providers/property/resource_akamai_property.go
+++ b/pkg/providers/property/resource_akamai_property.go
@@ -35,6 +35,26 @@ func resourceProperty() *schema.Resource {
 		}}
 	}
 
+	hashHostname := func(v interface{}) int {
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			return 0
+		}
+		cnameFrom, ok := m["cname_from"]
+		if !ok {
+			return 0
+		}
+		cnameTo, ok := m["cname_to"]
+		if !ok {
+			return 0
+		}
+		certProvisioningType, ok := m["cert_provisioning_type"]
+		if !ok {
+			return 0
+		}
+		return schema.HashString(fmt.Sprintf("%s.%s.%s", cnameFrom, cnameTo, certProvisioningType))
+	}
+
 	validateRules := func(val interface{}, _ cty.Path) diag.Diagnostics {
 		if len(val.(string)) == 0 {
 			return nil
@@ -182,25 +202,7 @@ func resourceProperty() *schema.Resource {
 			"hostnames": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Set: func(v interface{}) int {
-					m, ok := v.(map[string]interface{})
-					if !ok {
-						return 0
-					}
-					cnameFrom, ok := m["cname_from"]
-					if !ok {
-						return 0
-					}
-					cnameTo, ok := m["cname_to"]
-					if !ok {
-						return 0
-					}
-					certProvisioningType, ok := m["cert_provisioning_type"]
-					if !ok {
-						return 0
-					}
-					return schema.HashString(fmt.Sprintf("%s.%s.%s", cnameFrom, cnameTo, certProvisioningType))
-				},
+				Set:      hashHostname,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"cname_from": {

--- a/pkg/providers/property/resource_akamai_property_helpers_test.go
+++ b/pkg/providers/property/resource_akamai_property_helpers_test.go
@@ -119,7 +119,7 @@ func ExpectUpdatePropertyVersionHostnames(client *mockpapi, PropertyID, GroupID,
 }
 
 // Sets up an expected call to papi.GetPropertyVersions()
-func ExpectGetPropertyVersions(client *mockpapi, PropertyID, ContractID, GroupID string, versions papi.PropertyVersionItems, err error) *mock.Call {
+func ExpectGetPropertyVersions(client *mockpapi, PropertyID, PropertyName, ContractID, GroupID string, versionItems *papi.PropertyVersionItems, err error) *mock.Call {
 	req := papi.GetPropertyVersionsRequest{
 		PropertyID: PropertyID,
 		ContractID: ContractID,
@@ -128,14 +128,26 @@ func ExpectGetPropertyVersions(client *mockpapi, PropertyID, ContractID, GroupID
 	var res *papi.GetPropertyVersionsResponse
 	if err == nil {
 		res = &papi.GetPropertyVersionsResponse{
-			PropertyID: PropertyID,
-			ContractID: ContractID,
-			GroupID:    GroupID,
-			Versions:   versions,
+			PropertyID:   PropertyID,
+			PropertyName: PropertyName,
+			ContractID:   ContractID,
+			GroupID:      GroupID,
+			Versions:     *versionItems,
 		}
 	}
+	fn := func(context.Context, papi.GetPropertyVersionsRequest) (*papi.GetPropertyVersionsResponse, error) {
+		res = &papi.GetPropertyVersionsResponse{
+			PropertyID:   PropertyID,
+			PropertyName: PropertyName,
+			ContractID:   ContractID,
+			GroupID:      GroupID,
+			Versions:     *versionItems,
+		}
 
-	return client.On("GetPropertyVersions", AnyCTX, req).Return(res, err)
+		return res, nil
+	}
+
+	return client.OnGetPropertyVersions(AnyCTX, req, fn)
 }
 
 // Sets up an expected call to papi.GetPropertyVersion()

--- a/pkg/providers/property/resource_akamai_property_test.go
+++ b/pkg/providers/property/resource_akamai_property_test.go
@@ -15,11 +15,12 @@ import (
 func TestResProperty(t *testing.T) {
 	// These more or less track the state of a Property in PAPI for the lifecycle tests
 	type TestState struct {
-		Client     *mockpapi
-		Property   papi.Property
-		Hostnames  []papi.Hostname
-		Rules      papi.RulesUpdate
-		RuleFormat string
+		Client       *mockpapi
+		Property     papi.Property
+		Hostnames    []papi.Hostname
+		VersionItems papi.PropertyVersionItems
+		Rules        papi.RulesUpdate
+		RuleFormat   string
 	}
 
 	// BehaviorFuncs can be composed to define common patterns of mock PAPI behavior (for Lifecycle tests)
@@ -34,7 +35,7 @@ func TestResProperty(t *testing.T) {
 		}
 	}
 
-	UpdatePropertyVersionHostnames := func(PropertyID string, Version int, CnameTo string) BehaviorFunc {
+	SetHostnames := func(PropertyID string, Version int, CnameTo string) BehaviorFunc {
 		return func(State *TestState) {
 			NewHostnames := []papi.Hostname{{
 				CnameType:            "EDGE_HOSTNAME",
@@ -67,9 +68,13 @@ func TestResProperty(t *testing.T) {
 		}
 	}
 
-	GetPropertyVersions := func(PropertyID, ContractID, GroupID string, versionItems papi.PropertyVersionItems, err error) BehaviorFunc {
+	GetPropertyVersions := func(PropertyID, PropertyName, ContractID, GroupID string, err error, items ...papi.PropertyVersionItems) BehaviorFunc {
 		return func(State *TestState) {
-			ExpectGetPropertyVersions(State.Client, PropertyID, ContractID, GroupID, versionItems, err)
+			versionItems := &State.VersionItems
+			if len(items) > 0 {
+				versionItems = &items[0]
+			}
+			ExpectGetPropertyVersions(State.Client, PropertyID, PropertyName, ContractID, GroupID, versionItems, err)
 		}
 	}
 
@@ -93,6 +98,7 @@ func TestResProperty(t *testing.T) {
 				State.Rules = papi.RulesUpdate{}
 				State.Hostnames = nil
 				State.RuleFormat = ""
+				State.VersionItems = papi.PropertyVersionItems{}
 			})
 		}
 	}
@@ -103,26 +109,17 @@ func TestResProperty(t *testing.T) {
 		}
 	}
 
-	UpdateRuleTree := func() BehaviorFunc {
-		return func(State *TestState) {
-			ExpectUpdateRuleTree(State.Client, "prp_0", "grp_0", "ctr_0", 1,
-				&papi.RulesUpdate{Rules: papi.Rules{Name: "default"}}, "", nil)
-		}
-	}
-
-	CreateProperty := func(PropertyName, PropertyID string, latestVersion int, stagingVersion, productionVersion *int) BehaviorFunc {
+	CreateProperty := func(PropertyName, PropertyID string) BehaviorFunc {
 		return func(State *TestState) {
 			ExpectCreateProperty(State.Client, PropertyName, "grp_0", "ctr_0", "prd_0", PropertyID).Run(func(mock.Arguments) {
 
 				State.Property = papi.Property{
-					PropertyName:      PropertyName,
-					PropertyID:        PropertyID,
-					GroupID:           "grp_0",
-					ContractID:        "ctr_0",
-					ProductID:         "prd_0",
-					LatestVersion:     latestVersion,
-					StagingVersion:    stagingVersion,
-					ProductionVersion: productionVersion,
+					PropertyName:  PropertyName,
+					PropertyID:    PropertyID,
+					GroupID:       "grp_0",
+					ContractID:    "ctr_0",
+					ProductID:     "prd_0",
+					LatestVersion: 1,
 				}
 
 				State.Rules = papi.RulesUpdate{Rules: papi.Rules{Name: "default"}}
@@ -133,9 +130,9 @@ func TestResProperty(t *testing.T) {
 		}
 	}
 
-	PropertyLifecycle := func(PropertyName, PropertyID, GroupID string, latestVersion, stagingVersion, productionVersion int) BehaviorFunc {
+	PropertyLifecycle := func(PropertyName, PropertyID, GroupID string) BehaviorFunc {
 		return func(State *TestState) {
-			CreateProperty(PropertyName, PropertyID, latestVersion, &stagingVersion, &productionVersion)(State)
+			CreateProperty(PropertyName, PropertyID)(State)
 			GetVersionResources(PropertyID, "ctr_0", "grp_0", 1)(State)
 			DeleteProperty(PropertyID)(State)
 		}
@@ -146,6 +143,23 @@ func TestResProperty(t *testing.T) {
 			// Depending on how much of the import ID is given, the initial property lookup may not have group/contract
 			ExpectGetProperty(State.Client, "prp_0", "grp_0", "", &State.Property).Maybe()
 			ExpectGetProperty(State.Client, "prp_0", "", "", &State.Property).Maybe()
+		}
+	}
+
+	AdvanceVersion := func(PropertyID string, FromVersion, ToVersion int) BehaviorFunc {
+		return func(State *TestState) {
+			ExpectCreatePropertyVersion(State.Client, PropertyID, "grp_0", "ctr_0", FromVersion, ToVersion).Once().Run(func(mock.Arguments) {
+				State.Property.LatestVersion = ToVersion
+			}).Run(func(args mock.Arguments) {
+				State.Property.LatestVersion = ToVersion
+				State.VersionItems.Items = append(State.VersionItems.Items,
+					papi.PropertyVersionGetItem{
+						ProductionStatus: papi.VersionStatusInactive,
+						PropertyVersion:  ToVersion,
+						StagingStatus:    papi.VersionStatusInactive,
+					})
+			})
+			GetVersionResources(PropertyID, "ctr_0", "grp_0", ToVersion)(State)
 		}
 	}
 
@@ -180,248 +194,212 @@ func TestResProperty(t *testing.T) {
 	}
 
 	// Standard test behavior for cases where the property's latest version is deactivated in staging network
-	GetLatestVersionDeactivatedInStaging := func() LifecycleTestCase {
-		var stagingVersion, productionVersion *int
-		stagingVersion = new(int)
-		productionVersion = new(int)
-		*stagingVersion = 1
-		*productionVersion = 0
-		LatestVersionDeactivatedInStaging := LifecycleTestCase{
-			Name: "Latest version deactivated in staging",
-			ClientSetup: ComposeBehaviors(
-				PropertyLifecycle("test property", "prp_0", "grp_0", 1, 0, 0),
-				GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 1, papi.VersionStatusDeactivated, papi.VersionStatusInactive),
-				GetPropertyVersions("prp_0", "ctr_0", "grp_0", papi.PropertyVersionItems{Items: []papi.PropertyVersionGetItem{
-					{PropertyVersion: 1, StagingStatus: papi.VersionStatusActive, ProductionStatus: papi.VersionStatusInactive},
-					{PropertyVersion: 2, StagingStatus: papi.VersionStatusInactive, ProductionStatus: papi.VersionStatusActive}}}, nil),
-				CreateProperty("test property", "prp_0", 2, stagingVersion, productionVersion),
-				UpdatePropertyVersionHostnames("prp_0", 1, "to2.test.domain"),
-				UpdateRuleTree(),
-				DeleteProperty("prp_0"),
-				UpdatePropertyVersionHostnames("prp_0", 1, "to.test.domain"),
-				GetVersionResources("prp_0", "ctr_0", "grp_0", 2),
-				GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 2, papi.VersionStatusDeactivated, papi.VersionStatusInactive),
-			),
-			Steps: func(State *TestState, FixturePath string) []resource.TestStep {
-				return []resource.TestStep{
-					{
-						Config:             loadFixtureString("%s/step0.tf", FixturePath),
-						Check:              CheckAttrs("prp_0", "to.test.domain", "1", "0", "0", "ehn_123"),
-						ExpectNonEmptyPlan: true,
+	LatestVersionDeactivatedInStaging := LifecycleTestCase{
+		Name: "Latest version is active in staging",
+		ClientSetup: ComposeBehaviors(
+			PropertyLifecycle("test property", "prp_0", "grp_0"),
+			GetPropertyVersions("prp_0", "test property", "ctr_0", "grp_0", nil),
+			GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 1, papi.VersionStatusDeactivated, papi.VersionStatusInactive),
+			SetHostnames("prp_0", 1, "to.test.domain"),
+			AdvanceVersion("prp_0", 1, 2),
+			GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 2, papi.VersionStatusDeactivated, papi.VersionStatusInactive),
+			SetHostnames("prp_0", 2, "to2.test.domain"),
+		),
+		Steps: func(State *TestState, FixturePath string) []resource.TestStep {
+			return []resource.TestStep{
+				{
+					PreConfig: func() {
+						State.VersionItems = papi.PropertyVersionItems{
+							Items: []papi.PropertyVersionGetItem{{
+								ProductionStatus: papi.VersionStatusInactive,
+								PropertyVersion:  1,
+								StagingStatus:    papi.VersionStatusDeactivated,
+							}},
+						}
 					},
-					{
-						PreConfig: func() {
-							StagingVersion := 1
-							State.Property.StagingVersion = &StagingVersion
-						},
-						Config:             loadFixtureString("%s/step1.tf", FixturePath),
-						Check:              CheckAttrs("prp_0", "to2.test.domain", "2", "1", "0", "ehn_123"),
-						ExpectNonEmptyPlan: true,
+					Config: loadFixtureString("%s/step0.tf", FixturePath),
+					Check:  CheckAttrs("prp_0", "to.test.domain", "1", "0", "0", "ehn_123"),
+				},
+				{
+					PreConfig: func() {
+						StagingVersion := 1
+						State.Property.StagingVersion = &StagingVersion
 					},
-				}
-			},
-		}
-		return LatestVersionDeactivatedInStaging
+					Config: loadFixtureString("%s/step1.tf", FixturePath),
+					Check:  CheckAttrs("prp_0", "to2.test.domain", "2", "1", "0", "ehn_123"),
+				},
+			}
+		},
 	}
 
 	// Standard test behavior for cases where the property's latest version is deactivated in production network
-	GetLatestVersionDeactivatedInProd := func() LifecycleTestCase {
-		var stagingVersion, productionVersion *int
-		stagingVersion = new(int)
-		productionVersion = new(int)
-		*productionVersion = 1
-		LatestVersionDeactivatedInProd := LifecycleTestCase{
-			Name: "Latest version is not active in production",
-			ClientSetup: ComposeBehaviors(
-				PropertyLifecycle("test property", "prp_0", "grp_0", 1, 0, 0),
-				GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 1, papi.VersionStatusInactive, papi.VersionStatusDeactivated),
-				GetPropertyVersions("prp_0", "ctr_0", "grp_0", papi.PropertyVersionItems{Items: []papi.PropertyVersionGetItem{{PropertyVersion: 1}, {PropertyVersion: 2, ProductionStatus: papi.VersionStatusInactive}}}, nil),
-				CreateProperty("test property", "prp_0", 2, stagingVersion, productionVersion),
-				UpdatePropertyVersionHostnames("prp_0", 1, "to2.test.domain"),
-				UpdateRuleTree(),
-				DeleteProperty("prp_0"),
-				UpdatePropertyVersionHostnames("prp_0", 1, "to.test.domain"),
-				GetVersionResources("prp_0", "ctr_0", "grp_0", 2),
-				GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 2, papi.VersionStatusInactive, papi.VersionStatusDeactivated),
-			),
-			Steps: func(State *TestState, FixturePath string) []resource.TestStep {
-				return []resource.TestStep{
-					{
-						Config:             loadFixtureString("%s/step0.tf", FixturePath),
-						Check:              CheckAttrs("prp_0", "to.test.domain", "1", "0", "0", "ehn_123"),
-						ExpectNonEmptyPlan: true,
+	LatestVersionDeactivatedInProd := LifecycleTestCase{
+		Name: "Latest version is active in production",
+		ClientSetup: ComposeBehaviors(
+			PropertyLifecycle("test property", "prp_0", "grp_0"),
+			GetPropertyVersions("prp_0", "test property", "ctr_0", "grp_0", nil),
+			GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 1, papi.VersionStatusInactive, papi.VersionStatusDeactivated),
+			SetHostnames("prp_0", 1, "to.test.domain"),
+			AdvanceVersion("prp_0", 1, 2),
+			GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 2, papi.VersionStatusInactive, papi.VersionStatusDeactivated),
+			SetHostnames("prp_0", 2, "to2.test.domain"),
+		),
+		Steps: func(State *TestState, FixturePath string) []resource.TestStep {
+			return []resource.TestStep{
+				{
+					PreConfig: func() {
+						State.VersionItems = papi.PropertyVersionItems{
+							Items: []papi.PropertyVersionGetItem{{
+								ProductionStatus: papi.VersionStatusInactive,
+								PropertyVersion:  1,
+								StagingStatus:    papi.VersionStatusActive,
+							}},
+						}
 					},
-					{
-						PreConfig: func() {
-							ProductionVersion := 1
-							State.Property.ProductionVersion = &ProductionVersion
-						},
-						Config:             loadFixtureString("%s/step1.tf", FixturePath),
-						Check:              CheckAttrs("prp_0", "to2.test.domain", "2", "0", "1", "ehn_123"),
-						ExpectNonEmptyPlan: true,
+					Config: loadFixtureString("%s/step0.tf", FixturePath),
+					Check:  CheckAttrs("prp_0", "to.test.domain", "1", "0", "0", "ehn_123"),
+				},
+				{
+					PreConfig: func() {
+						ProductionVersion := 1
+						State.Property.ProductionVersion = &ProductionVersion
 					},
-				}
-			},
-		}
-		return LatestVersionDeactivatedInProd
+					Config: loadFixtureString("%s/step1.tf", FixturePath),
+					Check:  CheckAttrs("prp_0", "to2.test.domain", "2", "0", "1", "ehn_123"),
+				},
+			}
+		},
 	}
 
 	// Standard test behavior for cases where the property's latest version is active in staging network
-	GetLatestVersionActiveInStaging := func(updateruletree bool) LifecycleTestCase {
-		var staging = new(int)
-		*staging = 1
-		LatestVersionActiveInStaging := LifecycleTestCase{
-			Name: "Latest version is active in staging",
-			ClientSetup: ComposeBehaviors(
-				PropertyLifecycle("test property", "prp_0", "grp_0", 1, 0, 0),
-				GetPropertyVersions("prp_0", "ctr_0", "grp_0", papi.PropertyVersionItems{Items: []papi.PropertyVersionGetItem{{PropertyVersion: 1, StagingStatus: papi.VersionStatusInactive}, {PropertyVersion: 2, StagingStatus: papi.VersionStatusInactive}}}, nil),
-				CreateProperty("test property", "prp_0", 2, staging, nil),
-				GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 1, papi.VersionStatusActive, papi.VersionStatusInactive),
-				UpdatePropertyVersionHostnames("prp_0", 1, "to.test.domain"),
-				UpdatePropertyVersionHostnames("prp_0", 1, "to2.test.domain"),
-				GetVersionResources("prp_0", "ctr_0", "grp_0", 2),
-				GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 2, papi.VersionStatusActive, papi.VersionStatusInactive),
-				DeleteProperty("prp_0"),
-			),
-			Steps: func(State *TestState, FixturePath string) []resource.TestStep {
-				return []resource.TestStep{
-					{
-						Config:             loadFixtureString("%s/step0.tf", FixturePath),
-						Check:              CheckAttrs("prp_0", "to.test.domain", "1", "0", "0", "ehn_123"),
-						ExpectNonEmptyPlan: true,
+	LatestVersionActiveInStaging := LifecycleTestCase{
+		Name: "Latest version is active in staging",
+		ClientSetup: ComposeBehaviors(
+			PropertyLifecycle("test property", "prp_0", "grp_0"),
+			GetPropertyVersions("prp_0", "test property", "ctr_0", "grp_0", nil),
+			GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 1, papi.VersionStatusActive, papi.VersionStatusInactive),
+			SetHostnames("prp_0", 1, "to.test.domain"),
+			AdvanceVersion("prp_0", 1, 2),
+			GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 2, papi.VersionStatusInactive, papi.VersionStatusActive),
+			SetHostnames("prp_0", 2, "to2.test.domain"),
+		),
+		Steps: func(State *TestState, FixturePath string) []resource.TestStep {
+			return []resource.TestStep{
+				{
+					PreConfig: func() {
+						State.VersionItems = papi.PropertyVersionItems{
+							Items: []papi.PropertyVersionGetItem{{
+								ProductionStatus: papi.VersionStatusInactive,
+								PropertyVersion:  1,
+								StagingStatus:    papi.VersionStatusActive,
+							}},
+						}
 					},
-					{
-						PreConfig: func() {
-							StagingVersion := 1
-							State.Property.StagingVersion = &StagingVersion
-						},
-						Config:             loadFixtureString("%s/step1.tf", FixturePath),
-						Check:              CheckAttrs("prp_0", "to2.test.domain", "2", "1", "0", "ehn_123"),
-						ExpectNonEmptyPlan: true,
+					Config: loadFixtureString("%s/step0.tf", FixturePath),
+					Check:  CheckAttrs("prp_0", "to.test.domain", "1", "0", "0", "ehn_123"),
+				},
+				{
+					PreConfig: func() {
+						StagingVersion := 1
+						State.Property.StagingVersion = &StagingVersion
 					},
-				}
-			},
-		}
-		if updateruletree {
-			LatestVersionActiveInStaging.ClientSetup = ComposeBehaviors(LatestVersionActiveInStaging.ClientSetup, UpdateRuleTree())
-		}
-		return LatestVersionActiveInStaging
+					Config: loadFixtureString("%s/step1.tf", FixturePath),
+					Check:  CheckAttrs("prp_0", "to2.test.domain", "2", "1", "0", "ehn_123"),
+				},
+			}
+		},
 	}
 
 	// Standard test behavior for cases where the property's latest version is active in production network
-	GetLatestVersionActiveInProd := func(updateRuleTree bool) LifecycleTestCase {
-		var prodVersion = new(int)
-		*prodVersion = 1
-		LatestVersionActiveInProd := LifecycleTestCase{
-			Name: "Latest version is active in production",
-			ClientSetup: ComposeBehaviors(
-				PropertyLifecycle("test property", "prp_0", "grp_0", 1, 0, 0),
-				GetPropertyVersions("prp_0", "ctr_0", "grp_0", papi.PropertyVersionItems{Items: []papi.PropertyVersionGetItem{{PropertyVersion: 1}, {PropertyVersion: 2, ProductionStatus: papi.VersionStatusActive}}}, nil),
-				CreateProperty("test property", "prp_0", 2, nil, prodVersion),
-				GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 1, papi.VersionStatusInactive, papi.VersionStatusActive),
-				UpdatePropertyVersionHostnames("prp_0", 1, "to.test.domain"),
-				UpdatePropertyVersionHostnames("prp_0", 1, "to2.test.domain"),
-				GetVersionResources("prp_0", "ctr_0", "grp_0", 2),
-				GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 2, papi.VersionStatusInactive, papi.VersionStatusActive),
-				DeleteProperty("prp_0"),
-			),
-			Steps: func(State *TestState, FixturePath string) []resource.TestStep {
-				return []resource.TestStep{
-					{
-						Config:             loadFixtureString("%s/step0.tf", FixturePath),
-						Check:              CheckAttrs("prp_0", "to.test.domain", "1", "0", "0", "ehn_123"),
-						ExpectNonEmptyPlan: true,
+	LatestVersionActiveInProd := LifecycleTestCase{
+		Name: "Latest version is active in production",
+		ClientSetup: ComposeBehaviors(
+			PropertyLifecycle("test property", "prp_0", "grp_0"),
+			GetPropertyVersions("prp_0", "test property", "ctr_0", "grp_0", nil),
+			GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 1, papi.VersionStatusInactive, papi.VersionStatusActive),
+			SetHostnames("prp_0", 1, "to.test.domain"),
+			AdvanceVersion("prp_0", 1, 2),
+			GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 2, papi.VersionStatusInactive, papi.VersionStatusActive),
+			SetHostnames("prp_0", 2, "to2.test.domain"),
+		),
+		Steps: func(State *TestState, FixturePath string) []resource.TestStep {
+			return []resource.TestStep{
+				{
+					PreConfig: func() {
+						State.VersionItems = papi.PropertyVersionItems{
+							Items: []papi.PropertyVersionGetItem{{
+								ProductionStatus: papi.VersionStatusActive,
+								PropertyVersion:  1,
+								StagingStatus:    papi.VersionStatusInactive,
+							}},
+						}
 					},
-					{
-						PreConfig: func() {
-							ProductionVersion := 1
-							State.Property.ProductionVersion = &ProductionVersion
-						},
-						Config:             loadFixtureString("%s/step1.tf", FixturePath),
-						Check:              CheckAttrs("prp_0", "to2.test.domain", "2", "0", "1", "ehn_123"),
-						ExpectNonEmptyPlan: true,
+					Config: loadFixtureString("%s/step0.tf", FixturePath),
+					Check:  CheckAttrs("prp_0", "to.test.domain", "1", "0", "0", "ehn_123"),
+				},
+				{
+					PreConfig: func() {
+						ProductionVersion := 1
+						State.Property.ProductionVersion = &ProductionVersion
 					},
-				}
-			},
-		}
-
-		if updateRuleTree {
-			LatestVersionActiveInProd.ClientSetup = ComposeBehaviors(LatestVersionActiveInProd.ClientSetup, UpdateRuleTree())
-		}
-
-		return LatestVersionActiveInProd
+					Config: loadFixtureString("%s/step1.tf", FixturePath),
+					Check:  CheckAttrs("prp_0", "to2.test.domain", "2", "0", "1", "ehn_123"),
+				},
+			}
+		},
 	}
 
 	// Standard test behavior for cases where the property's latest version is not active
-	GetLatestVersionNotActive := func(updateruletree bool, hostnames []string) LifecycleTestCase {
-		LatestVersionNotActive := LifecycleTestCase{
-			Name: "Latest version not active",
-			ClientSetup: ComposeBehaviors(
-				PropertyLifecycle("test property", "prp_0", "grp_0", 1, 0, 0),
-				GetPropertyVersions("prp_0", "ctr_0", "grp_0", papi.PropertyVersionItems{Items: []papi.PropertyVersionGetItem{{PropertyVersion: 1}}}, nil),
-				CreateProperty("test property", "prp_0", 1, nil, nil),
-				DeleteProperty("prp_0"),
-				GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 1, papi.VersionStatusInactive, papi.VersionStatusInactive),
-			),
-			Steps: func(State *TestState, FixturePath string) []resource.TestStep {
-				return []resource.TestStep{
-					{
-						Config:             loadFixtureString("%s/step0.tf", FixturePath),
-						Check:              CheckAttrs("prp_0", "to.test.domain", "1", "0", "0", "ehn_123"),
-						ExpectNonEmptyPlan: true,
+	LatestVersionNotActive := LifecycleTestCase{
+		Name: "Latest version not active",
+		ClientSetup: ComposeBehaviors(
+			PropertyLifecycle("test property", "prp_0", "grp_0"),
+			GetPropertyVersions("prp_0", "test property", "ctr_0", "grp_0", nil),
+			GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 1, papi.VersionStatusInactive, papi.VersionStatusInactive),
+			SetHostnames("prp_0", 1, "to.test.domain"),
+			SetHostnames("prp_0", 1, "to2.test.domain"),
+		),
+		Steps: func(State *TestState, FixturePath string) []resource.TestStep {
+			return []resource.TestStep{
+				{
+					PreConfig: func() {
+						State.VersionItems = papi.PropertyVersionItems{Items: []papi.PropertyVersionGetItem{{PropertyVersion: 1, ProductionStatus: papi.VersionStatusInactive}}}
 					},
-					{
-						Config:             loadFixtureString("%s/step1.tf", FixturePath),
-						Check:              CheckAttrs("prp_0", "to2.test.domain", "1", "0", "0", "ehn_123"),
-						ExpectNonEmptyPlan: true,
-					},
-				}
-			},
-		}
-
-		for _, host := range hostnames {
-			LatestVersionNotActive.ClientSetup = ComposeBehaviors(LatestVersionNotActive.ClientSetup, UpdatePropertyVersionHostnames("prp_0", 1, host))
-		}
-
-		if updateruletree {
-			LatestVersionNotActive.ClientSetup = ComposeBehaviors(LatestVersionNotActive.ClientSetup, UpdateRuleTree())
-		}
-
-		return LatestVersionNotActive
+					Config: loadFixtureString("%s/step0.tf", FixturePath),
+					Check:  CheckAttrs("prp_0", "to.test.domain", "1", "0", "0", "ehn_123"),
+				},
+				{
+					Config: loadFixtureString("%s/step1.tf", FixturePath),
+					Check:  CheckAttrs("prp_0", "to2.test.domain", "1", "0", "0", "ehn_123"),
+				},
+			}
+		},
 	}
 
-	// Standard test behavior for cases where there is no diff in update
-	GetNoDiff := func() LifecycleTestCase {
-		var stagingVersion, productionVersion *int
-		stagingVersion = new(int)
-		productionVersion = new(int)
-		NoDiff := LifecycleTestCase{
-			Name: "No diff found in update",
-			ClientSetup: ComposeBehaviors(
-				PropertyLifecycle("test property", "prp_0", "grp_0", 1, 0, 0),
-				GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 1, papi.VersionStatusInactive, papi.VersionStatusInactive),
-				GetPropertyVersions("prp_0", "ctr_0", "grp_0", papi.PropertyVersionItems{Items: []papi.PropertyVersionGetItem{{PropertyVersion: 1}}}, nil),
-				CreateProperty("test property", "prp_0", 1, stagingVersion, productionVersion),
-				UpdatePropertyVersionHostnames("prp_0", 1, "to.test.domain"),
-				DeleteProperty("prp_0"),
-				UpdatePropertyVersionHostnames("prp_0", 1, "to.test.domain"),
-			),
-			Steps: func(State *TestState, FixturePath string) []resource.TestStep {
-				return []resource.TestStep{
-					{
-						Config:             loadFixtureString("%s/step0.tf", FixturePath),
-						Check:              CheckAttrs("prp_0", "to.test.domain", "1", "0", "0", "ehn_123"),
-						ExpectNonEmptyPlan: true,
+	// Standard test behavior for cases where the property's latest version is active in staging network
+	NoDiff := LifecycleTestCase{
+		Name: "No diff found in update",
+		ClientSetup: ComposeBehaviors(
+			PropertyLifecycle("test property", "prp_0", "grp_0"),
+			GetPropertyVersions("prp_0", "test property", "ctr_0", "grp_0", nil),
+			GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 1, papi.VersionStatusInactive, papi.VersionStatusInactive),
+			SetHostnames("prp_0", 1, "to.test.domain"),
+		),
+		Steps: func(State *TestState, FixturePath string) []resource.TestStep {
+			return []resource.TestStep{
+				{
+					PreConfig: func() {
+						State.VersionItems = papi.PropertyVersionItems{Items: []papi.PropertyVersionGetItem{{PropertyVersion: 1, ProductionStatus: papi.VersionStatusInactive}}}
 					},
-					{
-						Config:             loadFixtureString("%s/step1.tf", FixturePath),
-						Check:              CheckAttrs("prp_0", "to.test.domain", "1", "0", "0", "ehn_123"),
-						ExpectNonEmptyPlan: true,
-					},
-				}
-			},
-		}
-		return NoDiff
+					Config: loadFixtureString("%s/step0.tf", FixturePath),
+					Check:  CheckAttrs("prp_0", "to.test.domain", "1", "0", "0", "ehn_123"),
+				},
+				{
+					Config: loadFixtureString("%s/step1.tf", FixturePath),
+					Check:  CheckAttrs("prp_0", "to.test.domain", "1", "0", "0", "ehn_123"),
+				},
+			}
+		},
 	}
 
 	// Run a test case to verify schema validations
@@ -517,15 +495,12 @@ func TestResProperty(t *testing.T) {
 			client.Test(T{t})
 
 			setup := ComposeBehaviors(
-				PropertyLifecycle("test property", "prp_0", "grp_0", 1, 0, 0),
+				PropertyLifecycle("test property", "prp_0", "grp_0"),
 				GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 1, papi.VersionStatusInactive, papi.VersionStatusInactive),
-				GetPropertyVersions("prp_0", "ctr_0", "grp_0", papi.PropertyVersionItems{Items: []papi.PropertyVersionGetItem{{PropertyVersion: 1, ProductionStatus: papi.VersionStatusActive, StagingStatus: papi.VersionStatusActive}}}, nil),
-				CreateProperty("test property", "prp_0", 1, new(int), new(int)),
+				GetPropertyVersions("prp_0", "test property", "ctr_0", "grp_0", nil),
 				GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 1, papi.VersionStatusActive, papi.VersionStatusInactive),
-				UpdatePropertyVersionHostnames("prp_0", 1, "to.test.domain"),
-				DeleteProperty("prp_0"),
+				SetHostnames("prp_0", 1, "to.test.domain"),
 				ImportProperty("prp_0"),
-				UpdatePropertyVersionHostnames("prp_0", 1, "to.test.domain"),
 			)
 
 			parameters := strings.Split(ImportID, ",")
@@ -549,27 +524,27 @@ func TestResProperty(t *testing.T) {
 				setup = ComposeBehaviors(
 					setup,
 					GetVersionResources("prp_0", ContractID, GroupID, 1),
-					GetPropertyVersions("prp_0", ContractID, GroupID,
-						papi.PropertyVersionItems{Items: []papi.PropertyVersionGetItem{
-							{
-								PropertyVersion:  1,
-								StagingStatus:    papi.VersionStatusActive,
-								ProductionStatus: papi.VersionStatusActive,
-							},
-						}}, nil),
+					GetPropertyVersions("prp_0", "test property", ContractID, GroupID, nil),
 				)
 			}
 
-			setup(&TestState{Client: client})
-
-			useClient(client, func() {
-				resource.UnitTest(t, resource.TestCase{
-					Providers: testAccProviders,
-					Steps: []resource.TestStep{
+			kase := LifecycleTestCase{
+				Name:        "Importable",
+				ClientSetup: setup,
+				Steps: func(State *TestState, _ string) []resource.TestStep {
+					return []resource.TestStep{
 						{
-							Config:             loadFixtureString(fixturePath),
-							Check:              CheckAttrs("prp_0", "to.test.domain", "1", "0", "0", "ehn_123"),
-							ExpectNonEmptyPlan: true,
+							PreConfig: func() {
+								State.VersionItems = papi.PropertyVersionItems{Items: []papi.PropertyVersionGetItem{
+									{
+										PropertyVersion:  1,
+										StagingStatus:    papi.VersionStatusActive,
+										ProductionStatus: papi.VersionStatusActive,
+									},
+								}}
+							},
+							Config: loadFixtureString(fixturePath),
+							Check:  CheckAttrs("prp_0", "to.test.domain", "1", "0", "0", "ehn_123"),
 						},
 						{
 							ImportState:       true,
@@ -579,11 +554,18 @@ func TestResProperty(t *testing.T) {
 							Config:            loadFixtureString(fixturePath),
 						},
 						{
-							Config:             loadFixtureString(fixturePath),
-							Check:              CheckAttrs("prp_0", "to.test.domain", "1", "0", "0", "ehn_123"),
-							ExpectNonEmptyPlan: true,
+							Config: loadFixtureString(fixturePath),
+							Check:  CheckAttrs("prp_0", "to.test.domain", "1", "1", "1", "ehn_123"),
 						},
-					},
+					}
+				},
+			}
+			State := &TestState{Client: client}
+			kase.ClientSetup(State)
+			useClient(client, func() {
+				resource.UnitTest(t, resource.TestCase{
+					Providers: testAccProviders,
+					Steps:     kase.Steps(State, ""),
 				})
 			})
 
@@ -640,32 +622,32 @@ func TestResProperty(t *testing.T) {
 		AssertForbiddenAttr(t, "is_secure")
 		AssertForbiddenAttr(t, "variables")
 
-		AssertLifecycle(t, "normal", GetLatestVersionNotActive(true, []string{"to2.test.domain", "to.test.domain"}))
-		AssertLifecycle(t, "normal", GetLatestVersionActiveInStaging(true))
-		AssertLifecycle(t, "normal", GetLatestVersionActiveInProd(true))
-		AssertLifecycle(t, "normal", GetLatestVersionDeactivatedInStaging())
-		AssertLifecycle(t, "normal", GetLatestVersionDeactivatedInProd())
-		AssertLifecycle(t, "contract_id without prefix", GetLatestVersionNotActive(false, []string{"to2.test.domain", "to.test.domain"}))
-		AssertLifecycle(t, "contract_id without prefix", GetLatestVersionActiveInStaging(false))
-		AssertLifecycle(t, "contract_id without prefix", GetLatestVersionActiveInProd(false))
-		AssertLifecycle(t, "contract without prefix", GetLatestVersionNotActive(false, []string{"to2.test.domain", "to.test.domain"}))
-		AssertLifecycle(t, "contract without prefix", GetLatestVersionActiveInStaging(false))
-		AssertLifecycle(t, "contract without prefix", GetLatestVersionActiveInProd(false))
-		AssertLifecycle(t, "group_id without prefix", GetLatestVersionNotActive(false, []string{"to2.test.domain", "to.test.domain"}))
-		AssertLifecycle(t, "group_id without prefix", GetLatestVersionActiveInStaging(false))
-		AssertLifecycle(t, "group_id without prefix", GetLatestVersionActiveInProd(false))
-		AssertLifecycle(t, "group without prefix", GetLatestVersionNotActive(false, []string{"to2.test.domain", "to.test.domain"}))
-		AssertLifecycle(t, "group without prefix", GetLatestVersionActiveInStaging(false))
-		AssertLifecycle(t, "group without prefix", GetLatestVersionActiveInProd(false))
-		AssertLifecycle(t, "product_id without prefix", GetLatestVersionNotActive(false, []string{"to2.test.domain", "to.test.domain"}))
-		AssertLifecycle(t, "product_id without prefix", GetLatestVersionActiveInStaging(false))
-		AssertLifecycle(t, "product_id without prefix", GetLatestVersionActiveInProd(false))
-		AssertLifecycle(t, "product without prefix", GetLatestVersionNotActive(false, []string{"to2.test.domain", "to.test.domain"}))
-		AssertLifecycle(t, "product without prefix", GetLatestVersionActiveInStaging(false))
-		AssertLifecycle(t, "product without prefix", GetLatestVersionActiveInProd(false))
-		AssertLifecycle(t, "no diff", GetNoDiff())
-		AssertLifecycle(t, "product to product_id", GetNoDiff())
-		AssertLifecycle(t, "product_id to product", GetNoDiff())
+		AssertLifecycle(t, "normal", LatestVersionNotActive)
+		AssertLifecycle(t, "normal", LatestVersionActiveInStaging)
+		AssertLifecycle(t, "normal", LatestVersionActiveInProd)
+		AssertLifecycle(t, "normal", LatestVersionDeactivatedInStaging)
+		AssertLifecycle(t, "normal", LatestVersionDeactivatedInProd)
+		AssertLifecycle(t, "contract_id without prefix", LatestVersionNotActive)
+		AssertLifecycle(t, "contract_id without prefix", LatestVersionActiveInStaging)
+		AssertLifecycle(t, "contract_id without prefix", LatestVersionActiveInProd)
+		AssertLifecycle(t, "contract without prefix", LatestVersionNotActive)
+		AssertLifecycle(t, "contract without prefix", LatestVersionActiveInStaging)
+		AssertLifecycle(t, "contract without prefix", LatestVersionActiveInProd)
+		AssertLifecycle(t, "group_id without prefix", LatestVersionNotActive)
+		AssertLifecycle(t, "group_id without prefix", LatestVersionActiveInStaging)
+		AssertLifecycle(t, "group_id without prefix", LatestVersionActiveInProd)
+		AssertLifecycle(t, "group without prefix", LatestVersionNotActive)
+		AssertLifecycle(t, "group without prefix", LatestVersionActiveInStaging)
+		AssertLifecycle(t, "group without prefix", LatestVersionActiveInProd)
+		AssertLifecycle(t, "product_id without prefix", LatestVersionNotActive)
+		AssertLifecycle(t, "product_id without prefix", LatestVersionActiveInStaging)
+		AssertLifecycle(t, "product_id without prefix", LatestVersionActiveInProd)
+		AssertLifecycle(t, "product without prefix", LatestVersionNotActive)
+		AssertLifecycle(t, "product without prefix", LatestVersionActiveInStaging)
+		AssertLifecycle(t, "product without prefix", LatestVersionActiveInProd)
+		AssertLifecycle(t, "no diff", NoDiff)
+		AssertLifecycle(t, "product to product_id", NoDiff)
+		AssertLifecycle(t, "product_id to product", NoDiff)
 
 		AssertImportable(t, "property_id", "prp_0")
 		AssertImportable(t, "property_id and ver_# version", "prp_0,ver_1")
@@ -692,23 +674,27 @@ func TestResProperty(t *testing.T) {
 			client := &mockpapi{}
 			client.Test(T{t})
 
-			var ver1, ver2 *int
-			ver1 = new(int)
-			ver2 = new(int)
-			*ver1 = 1
-			*ver2 = 2
-
 			setup := ComposeBehaviors(
-				PropertyLifecycle("test property", "prp_0", "grp_0", 1, 0, 0),
+				PropertyLifecycle("test property", "prp_0", "grp_0"),
+				GetPropertyVersions("prp_0", "test property", "ctr_0", "grp_0", nil, papi.PropertyVersionItems{Items: []papi.PropertyVersionGetItem{
+					{
+						PropertyVersion:  1,
+						StagingStatus:    papi.VersionStatusInactive,
+						ProductionStatus: papi.VersionStatusInactive,
+					},
+				}}),
 				GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 1, papi.VersionStatusInactive, papi.VersionStatusInactive),
-				GetPropertyVersions("prp_0", "ctr_0", "grp_0", papi.PropertyVersionItems{Items: []papi.PropertyVersionGetItem{{PropertyVersion: 1}}}, nil),
-				GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 1, papi.VersionStatusActive, papi.VersionStatusInactive),
-				UpdatePropertyVersionHostnames("prp_0", 1, "to.test.domain"),
-				PropertyLifecycle("renamed property", "prp_1", "grp_0", 1, 1, 1),
+				PropertyLifecycle("renamed property", "prp_1", "grp_0"),
+				GetPropertyVersions("prp_1", "renamed property", "ctr_0", "grp_0", nil, papi.PropertyVersionItems{Items: []papi.PropertyVersionGetItem{
+					{
+						PropertyVersion:  1,
+						StagingStatus:    papi.VersionStatusInactive,
+						ProductionStatus: papi.VersionStatusInactive,
+					},
+				}}),
 				GetPropertyVersionResources("prp_1", "grp_0", "ctr_0", 1, papi.VersionStatusInactive, papi.VersionStatusInactive),
-				GetPropertyVersions("prp_1", "ctr_0", "grp_0", papi.PropertyVersionItems{Items: []papi.PropertyVersionGetItem{{PropertyVersion: 1}}}, nil),
-				GetPropertyVersions("prp_0", "ctr_0", "grp_0", papi.PropertyVersionItems{Items: []papi.PropertyVersionGetItem{{PropertyVersion: 1}}}, nil),
-				UpdatePropertyVersionHostnames("prp_1", 1, "to2.test.domain"),
+				SetHostnames("prp_0", 1, "to.test.domain"),
+				SetHostnames("prp_1", 1, "to2.test.domain"),
 			)
 			setup(&TestState{Client: client})
 
@@ -717,9 +703,8 @@ func TestResProperty(t *testing.T) {
 					Providers: testAccProviders,
 					Steps: []resource.TestStep{
 						{
-							Config:             loadFixtureString("testdata/%s-step0.tf", t.Name()),
-							Check:              CheckAttrs("prp_0", "to.test.domain", "1", "0", "0", "ehn_123"),
-							ExpectNonEmptyPlan: true,
+							Config: loadFixtureString("testdata/%s-step0.tf", t.Name()),
+							Check:  CheckAttrs("prp_0", "to.test.domain", "1", "0", "0", "ehn_123"),
 						},
 						{
 							Config: loadFixtureString("testdata/%s-step1.tf", t.Name()),
@@ -727,7 +712,6 @@ func TestResProperty(t *testing.T) {
 								resource.TestCheckResourceAttr("akamai_property.test", "id", "prp_1"),
 								resource.TestCheckResourceAttr("akamai_property.test", "name", "renamed property"),
 							),
-							ExpectNonEmptyPlan: true,
 						},
 					},
 				})
@@ -741,12 +725,18 @@ func TestResProperty(t *testing.T) {
 			client.Test(T{t})
 
 			setup := ComposeBehaviors(
-				CreateProperty("test property", "prp_0", 1, new(int), new(int)),
+				CreateProperty("test property", "prp_0"),
 				GetProperty("prp_0"),
+				GetPropertyVersions("prp_0", "test property", "ctr_0", "grp_0", nil, papi.PropertyVersionItems{Items: []papi.PropertyVersionGetItem{
+					{
+						PropertyVersion:  1,
+						StagingStatus:    papi.VersionStatusInactive,
+						ProductionStatus: papi.VersionStatusInactive,
+					},
+				}}),
 				GetVersionResources("prp_0", "ctr_0", "grp_0", 1),
 				GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 1, "ctr_0", "grp_0"),
-				UpdatePropertyVersionHostnames("prp_0", 1, "to.test.domain"),
-				GetPropertyVersions("prp_0", "ctr_0", "grp_0", papi.PropertyVersionItems{Items: []papi.PropertyVersionGetItem{{PropertyVersion: 1, ProductionStatus: papi.VersionStatusActive}}}, nil),
+				SetHostnames("prp_0", 1, "to.test.domain"),
 			)
 			setup(&TestState{Client: client})
 
@@ -768,14 +758,12 @@ func TestResProperty(t *testing.T) {
 					Providers: testAccProviders,
 					Steps: []resource.TestStep{
 						{
-							Config:             loadFixtureString("testdata/%s/step0.tf", t.Name()),
-							Check:              CheckAttrs("prp_0", "to.test.domain", "1", "0", "0", "ehn_123"),
-							ExpectNonEmptyPlan: true,
+							Config: loadFixtureString("testdata/%s/step0.tf", t.Name()),
+							Check:  CheckAttrs("prp_0", "to.test.domain", "1", "0", "0", "ehn_123"),
 						},
 						{
-							Config:             loadFixtureString("testdata/%s/step1.tf", t.Name()),
-							ExpectError:        regexp.MustCompile(`cannot remove active property`),
-							ExpectNonEmptyPlan: true,
+							Config:      loadFixtureString("testdata/%s/step1.tf", t.Name()),
+							ExpectError: regexp.MustCompile(`cannot remove active property`),
 						},
 					},
 				})
@@ -909,6 +897,14 @@ func TestResProperty(t *testing.T) {
 				"ctr_0", "prd_0", "prp_0",
 			)
 
+			ExpectGetPropertyVersions(client, "prp_0", "test property", "ctr_0", "grp_0", &papi.PropertyVersionItems{Items: []papi.PropertyVersionGetItem{
+				{
+					PropertyVersion:  1,
+					StagingStatus:    papi.VersionStatusInactive,
+					ProductionStatus: papi.VersionStatusInactive,
+				},
+			}}, nil)
+
 			ExpectGetPropertyVersion(client, "prp_0", "grp_0", "ctr_0", 1, papi.VersionStatusInactive, papi.VersionStatusInactive)
 
 			ExpectUpdatePropertyVersionHostnames(
@@ -920,30 +916,6 @@ func TestResProperty(t *testing.T) {
 					CertProvisioningType: "DEFAULT",
 				}},
 			).Once()
-
-			ExpectGetPropertyVersions(client, "prp_0", "ctr_0", "grp_0", papi.PropertyVersionItems{Items: []papi.PropertyVersionGetItem{{PropertyVersion: 1}}}, nil)
-
-			ExpectCreateProperty(client, "test property", "grp_0", "ctr_0", "prd_0", "prp_0").Run(func(mock.Arguments) {
-
-				Property := papi.Property{
-					PropertyName:  "test property",
-					PropertyID:    "prp_0",
-					GroupID:       "grp_0",
-					ContractID:    "ctr_0",
-					ProductID:     "prd_0",
-					LatestVersion: 1,
-				}
-
-				Rules := papi.RulesUpdate{Rules: papi.Rules{Name: "default"}}
-				RuleFormat := "v2020-01-01"
-				ExpectGetProperty(client, "prp_0", "grp_0", "ctr_0", &Property)
-				ExpectGetPropertyVersionHostnames(client, "prp_0", "grp_0", "ctr_0", 1, &[]papi.Hostname{})
-				ExpectGetRuleTree(client, "prp_0", "grp_0", "ctr_0", 1, &Rules, &RuleFormat)
-			}).Once()
-
-			UpdatePropertyVersionHostnames("prp_0", 1, "to.test.domain")
-			UpdateRuleTree()
-			DeleteProperty("prp_0")
 
 			ExpectGetProperty(
 				client, "prp_0", "grp_0", "ctr_0",
@@ -985,9 +957,8 @@ func TestResProperty(t *testing.T) {
 					Providers: testAccProviders,
 					Steps: []resource.TestStep{
 						{
-							Config:             loadFixtureString("testdata/TestResProperty/CreationUpdateNoHostnames/creation/property_create.tf"),
-							Check:              resource.TestCheckResourceAttr("akamai_property.test", "id", "prp_0"),
-							ExpectNonEmptyPlan: true,
+							Config: loadFixtureString("testdata/TestResProperty/CreationUpdateNoHostnames/creation/property_create.tf"),
+							Check:  resource.TestCheckResourceAttr("akamai_property.test", "id", "prp_0"),
 						},
 						{
 							Config: loadFixtureString("testdata/TestResProperty/CreationUpdateNoHostnames/update/property_update.tf"),
@@ -995,8 +966,7 @@ func TestResProperty(t *testing.T) {
 								resource.TestCheckResourceAttr("akamai_property.test", "id", "prp_0"),
 								resource.TestCheckResourceAttr("akamai_property.test", "hostnames.#", "0"),
 							),
-							ExpectError:        regexp.MustCompile("atleast one hostname required to update existing list of hostnames associated to a property"),
-							ExpectNonEmptyPlan: true,
+							ExpectError: regexp.MustCompile("atleast one hostname required to update existing list of hostnames associated to a property"),
 						},
 					},
 				})

--- a/pkg/providers/property/resource_akamai_property_test.go
+++ b/pkg/providers/property/resource_akamai_property_test.go
@@ -77,6 +77,61 @@ func TestResProperty(t *testing.T) {
 		}
 	}
 
+	SetHostnames2 := func(PropertyID string, Version int, CnameFrom1, CnameTo1, CnameFrom2, CnameTo2 string) BehaviorFunc {
+		return func(State *TestState) {
+			NewHostnames := []papi.Hostname{{
+				CnameType:            "EDGE_HOSTNAME",
+				CnameFrom:            CnameFrom1,
+				CnameTo:              CnameTo1,
+				CertProvisioningType: "DEFAULT",
+			}, {
+				CnameType:            "EDGE_HOSTNAME",
+				CnameFrom:            CnameFrom2,
+				CnameTo:              CnameTo2,
+				CertProvisioningType: "DEFAULT",
+			}}
+
+			ExpectUpdatePropertyVersionHostnames(State.Client, PropertyID, "grp_0", "ctr_0", Version, NewHostnames).Once().Run(func(mock.Arguments) {
+				NewResponseHostnames := []papi.Hostname{{
+					CnameType:            "EDGE_HOSTNAME",
+					CnameFrom:            CnameFrom1,
+					CnameTo:              CnameTo1,
+					CertProvisioningType: "DEFAULT",
+					EdgeHostnameID:       "ehn_123",
+					CertStatus: papi.CertStatusItem{
+						ValidationCname: papi.ValidationCname{
+							Hostname: "_acme-challenge.www.example.com",
+							Target:   "{token}.www.example.com.akamai-domain.com",
+						},
+						Staging: []papi.StatusItem{{Status: "PENDING"}},
+						Production: []papi.StatusItem{{
+							Status: "PENDING",
+						},
+						},
+					},
+				}, {
+					CnameType:            "EDGE_HOSTNAME",
+					CnameFrom:            CnameFrom2,
+					CnameTo:              CnameTo2,
+					CertProvisioningType: "DEFAULT",
+					EdgeHostnameID:       "ehn_123",
+					CertStatus: papi.CertStatusItem{
+						ValidationCname: papi.ValidationCname{
+							Hostname: "_acme-challenge.www.example.com",
+							Target:   "{token}.www.example.com.akamai-domain.com",
+						},
+						Staging: []papi.StatusItem{{Status: "PENDING"}},
+						Production: []papi.StatusItem{{
+							Status: "PENDING",
+						},
+						},
+					},
+				}}
+				State.Hostnames = append([]papi.Hostname{}, NewResponseHostnames...)
+			})
+		}
+	}
+
 	GetPropertyVersions := func(PropertyID, PropertyName, ContractID, GroupID string, err error, items ...papi.PropertyVersionItems) BehaviorFunc {
 		return func(State *TestState) {
 			versionItems := &State.VersionItems
@@ -429,7 +484,35 @@ func TestResProperty(t *testing.T) {
 			}
 		},
 	}
-
+	NoDiffForHostnames := LifecycleTestCase{
+		Name: "No diff found in update",
+		ClientSetup: ComposeBehaviors(
+			PropertyLifecycle("test property", "prp_0", "grp_0",
+				papi.RulesUpdate{Rules: papi.Rules{Children: []papi.Rules{{Name: "Default CORS Policy", CriteriaMustSatisfy: papi.RuleCriteriaMustSatisfyAll}}}}),
+			GetPropertyVersions("prp_0", "test property", "ctr_0", "grp_0", nil),
+			GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 1, papi.VersionStatusInactive, papi.VersionStatusInactive),
+			SetHostnames2("prp_0", 1, "from1.test.domain", "to1.test.domain", "from2.test.domain", "to2.test.domain"),
+			UpdateRuleTree("prp_0", "ctr_0", "grp_0", 1,
+				&papi.RulesUpdate{Rules: papi.Rules{Children: []papi.Rules{{CriteriaMustSatisfy: papi.RuleCriteriaMustSatisfyAll, Name: "Default CORS Policy"}}}}),
+		),
+		Steps: func(State *TestState, FixturePath string) []resource.TestStep {
+			return []resource.TestStep{
+				{
+					PreConfig: func() {
+						State.VersionItems = papi.PropertyVersionItems{Items: []papi.PropertyVersionGetItem{{PropertyVersion: 1, ProductionStatus: papi.VersionStatusInactive}}}
+					},
+					Config: loadFixtureString("%s/step0.tf", FixturePath),
+					Check: CheckAttrs("prp_0", "to1.test.domain", "1", "0", "0", "ehn_123",
+						`{"rules":{"children":[{"name":"Default CORS Policy","options":{},"criteriaMustSatisfy":"all"}],"name":"","options":{}}}`),
+				},
+				{
+					Config: loadFixtureString("%s/step1.tf", FixturePath),
+					Check: CheckAttrs("prp_0", "to1.test.domain", "1", "0", "0", "ehn_123",
+						`{"rules":{"children":[{"name":"Default CORS Policy","options":{},"criteriaMustSatisfy":"all"}],"name":"","options":{}}}`),
+				},
+			}
+		},
+	}
 	// Run a test case to verify schema validations
 	AssertConfigError := func(t *testing.T, flaw, rx string) {
 		t.Helper()
@@ -681,6 +764,7 @@ func TestResProperty(t *testing.T) {
 		AssertLifecycle(t, "no diff", NoDiff)
 		AssertLifecycle(t, "product to product_id", NoDiff)
 		AssertLifecycle(t, "product_id to product", NoDiff)
+		AssertLifecycle(t, "hostnames", NoDiffForHostnames)
 
 		AssertImportable(t, "property_id", "prp_0")
 		AssertImportable(t, "property_id and ver_# version", "prp_0,ver_1")
@@ -925,7 +1009,7 @@ func TestResProperty(t *testing.T) {
 			client.AssertExpectations(t)
 		})
 
-		t.Run("validation - empty plan, when updating a property hostnames to empty", func(t *testing.T) {
+		t.Run("validation - when updating a property hostnames to empty it should return error", func(t *testing.T) {
 			client := &mockpapi{}
 			client.Test(T{t})
 
@@ -1003,7 +1087,7 @@ func TestResProperty(t *testing.T) {
 								resource.TestCheckResourceAttr("akamai_property.test", "id", "prp_0"),
 								resource.TestCheckResourceAttr("akamai_property.test", "hostnames.#", "0"),
 							),
-							ExpectError: regexp.MustCompile("atleast one hostname required to update existing list of hostnames associated to a property"),
+							ExpectError: regexp.MustCompile("at least one hostname required to update existing list of hostnames associated to a property"),
 						},
 					},
 				})

--- a/pkg/providers/property/resource_akamai_property_test.go
+++ b/pkg/providers/property/resource_akamai_property_test.go
@@ -77,7 +77,7 @@ func TestResProperty(t *testing.T) {
 		}
 	}
 
-	SetHostnames2 := func(PropertyID string, Version int, CnameFrom1, CnameTo1, CnameFrom2, CnameTo2 string) BehaviorFunc {
+	SetTwoHostnames := func(PropertyID string, Version int, CnameFrom1, CnameTo1, CnameFrom2, CnameTo2 string) BehaviorFunc {
 		return func(State *TestState) {
 			NewHostnames := []papi.Hostname{{
 				CnameType:            "EDGE_HOSTNAME",
@@ -491,7 +491,7 @@ func TestResProperty(t *testing.T) {
 				papi.RulesUpdate{Rules: papi.Rules{Children: []papi.Rules{{Name: "Default CORS Policy", CriteriaMustSatisfy: papi.RuleCriteriaMustSatisfyAll}}}}),
 			GetPropertyVersions("prp_0", "test property", "ctr_0", "grp_0", nil),
 			GetPropertyVersionResources("prp_0", "grp_0", "ctr_0", 1, papi.VersionStatusInactive, papi.VersionStatusInactive),
-			SetHostnames2("prp_0", 1, "from1.test.domain", "to1.test.domain", "from2.test.domain", "to2.test.domain"),
+			SetTwoHostnames("prp_0", 1, "from1.test.domain", "to1.test.domain", "from2.test.domain", "to2.test.domain"),
 			UpdateRuleTree("prp_0", "ctr_0", "grp_0", 1,
 				&papi.RulesUpdate{Rules: papi.Rules{Children: []papi.Rules{{CriteriaMustSatisfy: papi.RuleCriteriaMustSatisfyAll, Name: "Default CORS Policy"}}}}),
 		),

--- a/pkg/providers/property/testdata/TestResProperty/Lifecycle/hostnames/step0.tf
+++ b/pkg/providers/property/testdata/TestResProperty/Lifecycle/hostnames/step0.tf
@@ -1,0 +1,28 @@
+provider "akamai" {
+  edgerc = "~/.edgerc"
+}
+
+resource "akamai_property" "test" {
+  name = "test property"
+  contract_id = "ctr_0"
+  group_id    = "grp_0"
+  product_id  = "prd_0"
+
+  hostnames {
+    cname_to= "to1.test.domain"
+    cname_from="from1.test.domain"
+    cert_provisioning_type= "DEFAULT"
+  }
+  hostnames {
+    cname_to= "to2.test.domain"
+    cname_from="from2.test.domain"
+    cert_provisioning_type= "DEFAULT"
+  }
+
+  rules = data.akamai_property_rules_template.akarules.json
+
+}
+
+data "akamai_property_rules_template" "akarules" {
+  template_file = "testdata/TestResProperty/Lifecycle/property-snippets/rules1.json"
+}

--- a/pkg/providers/property/testdata/TestResProperty/Lifecycle/hostnames/step1.tf
+++ b/pkg/providers/property/testdata/TestResProperty/Lifecycle/hostnames/step1.tf
@@ -1,0 +1,28 @@
+provider "akamai" {
+  edgerc = "~/.edgerc"
+}
+
+resource "akamai_property" "test" {
+  name = "test property"
+  contract_id = "ctr_0"
+  group_id    = "grp_0"
+  product_id  = "prd_0"
+
+  hostnames {
+    cname_to= "to2.test.domain"
+    cname_from="from2.test.domain"
+    cert_provisioning_type= "DEFAULT"
+  }
+  hostnames {
+    cname_to= "to1.test.domain"
+    cname_from="from1.test.domain"
+    cert_provisioning_type= "DEFAULT"
+  }
+
+  rules = data.akamai_property_rules_template.akarules.json
+
+}
+
+data "akamai_property_rules_template" "akarules" {
+  template_file = "testdata/TestResProperty/Lifecycle/property-snippets/rules1.json"
+}

--- a/pkg/providers/property/testdata/TestResProperty/Lifecycle/no diff/step0.tf
+++ b/pkg/providers/property/testdata/TestResProperty/Lifecycle/no diff/step0.tf
@@ -8,10 +8,16 @@ resource "akamai_property" "test" {
   group_id    = "grp_0"
   product  = "prd_0"
 
+  rules = data.akamai_property_rules_template.akarules.json
+
   hostnames {
     cname_to= "to.test.domain"
     cname_from="from.test.domain"
     cert_provisioning_type= "DEFAULT"
   }
 
+}
+
+data "akamai_property_rules_template" "akarules" {
+  template_file = "testdata/TestResProperty/Lifecycle/property-snippets/rules0.json"
 }

--- a/pkg/providers/property/testdata/TestResProperty/Lifecycle/no diff/step1.tf
+++ b/pkg/providers/property/testdata/TestResProperty/Lifecycle/no diff/step1.tf
@@ -8,10 +8,16 @@ resource "akamai_property" "test" {
   group_id    = "grp_0"
   product  = "prd_0"
 
+  rules = data.akamai_property_rules_template.akarules.json
+
   hostnames {
     cname_to= "to.test.domain"
     cname_from="from.test.domain"
     cert_provisioning_type= "DEFAULT"
   }
 
+}
+
+data "akamai_property_rules_template" "akarules" {
+  template_file = "testdata/TestResProperty/Lifecycle/property-snippets/rules1.json"
 }

--- a/pkg/providers/property/testdata/TestResProperty/Lifecycle/product to product_id/step0.tf
+++ b/pkg/providers/property/testdata/TestResProperty/Lifecycle/product to product_id/step0.tf
@@ -14,4 +14,10 @@ resource "akamai_property" "test" {
     cert_provisioning_type= "DEFAULT"
   }
 
+  rules = data.akamai_property_rules_template.akarules.json
+
+}
+
+data "akamai_property_rules_template" "akarules" {
+  template_file = "testdata/TestResProperty/Lifecycle/property-snippets/rules1.json"
 }

--- a/pkg/providers/property/testdata/TestResProperty/Lifecycle/product to product_id/step1.tf
+++ b/pkg/providers/property/testdata/TestResProperty/Lifecycle/product to product_id/step1.tf
@@ -14,4 +14,10 @@ resource "akamai_property" "test" {
     cert_provisioning_type= "DEFAULT"
   }
 
+  rules = data.akamai_property_rules_template.akarules.json
+
+}
+
+data "akamai_property_rules_template" "akarules" {
+  template_file = "testdata/TestResProperty/Lifecycle/property-snippets/rules1.json"
 }

--- a/pkg/providers/property/testdata/TestResProperty/Lifecycle/product_id to product/step0.tf
+++ b/pkg/providers/property/testdata/TestResProperty/Lifecycle/product_id to product/step0.tf
@@ -14,4 +14,10 @@ resource "akamai_property" "test" {
     cert_provisioning_type= "DEFAULT"
   }
 
+  rules = data.akamai_property_rules_template.akarules.json
+
+}
+
+data "akamai_property_rules_template" "akarules" {
+  template_file = "testdata/TestResProperty/Lifecycle/property-snippets/rules1.json"
 }

--- a/pkg/providers/property/testdata/TestResProperty/Lifecycle/product_id to product/step1.tf
+++ b/pkg/providers/property/testdata/TestResProperty/Lifecycle/product_id to product/step1.tf
@@ -14,4 +14,10 @@ resource "akamai_property" "test" {
     cert_provisioning_type= "DEFAULT"
   }
 
+  rules = data.akamai_property_rules_template.akarules.json
+
+}
+
+data "akamai_property_rules_template" "akarules" {
+  template_file = "testdata/TestResProperty/Lifecycle/property-snippets/rules1.json"
 }

--- a/pkg/providers/property/testdata/TestResProperty/Lifecycle/property-snippets/rules0.json
+++ b/pkg/providers/property/testdata/TestResProperty/Lifecycle/property-snippets/rules0.json
@@ -1,0 +1,10 @@
+{
+  "rules": {
+    "children": [
+      {
+        "name": "Default CORS Policy",
+        "criteriaMustSatisfy": "all"
+      }
+    ]
+  }
+}

--- a/pkg/providers/property/testdata/TestResProperty/Lifecycle/property-snippets/rules1.json
+++ b/pkg/providers/property/testdata/TestResProperty/Lifecycle/property-snippets/rules1.json
@@ -1,0 +1,10 @@
+{
+  "rules": {
+    "children": [
+      {
+        "criteriaMustSatisfy": "all",
+        "name": "Default CORS Policy"
+      }
+    ]
+  }
+}

--- a/pkg/providers/property/testdata/TestResProperty/Lifecycle/rules custom diff/property-snippets/rules0.json
+++ b/pkg/providers/property/testdata/TestResProperty/Lifecycle/rules custom diff/property-snippets/rules0.json
@@ -1,0 +1,17 @@
+{
+  "rules":{
+    "behaviors":[
+      {
+        "name":"caching",
+        "options":{
+          "behavior":"MAX_AGE",
+          "mustRevalidate":false,
+          "ttl":"12d"
+        }
+      }
+    ],
+    "name":"default",
+    "children": [],
+    "criteria": []
+  }
+}

--- a/pkg/providers/property/testdata/TestResProperty/Lifecycle/rules custom diff/property-snippets/rules1.json
+++ b/pkg/providers/property/testdata/TestResProperty/Lifecycle/rules custom diff/property-snippets/rules1.json
@@ -1,0 +1,17 @@
+{
+  "rules":{
+    "behaviors":[
+      {
+        "name":"caching",
+        "options":{
+          "behavior":"MAX_AGE",
+          "mustRevalidate":false,
+          "ttl":"13d"
+        }
+      }
+    ],
+    "name":"default",
+    "children": [],
+    "criteria": []
+  }
+}

--- a/pkg/providers/property/testdata/TestResProperty/Lifecycle/rules custom diff/step0.tf
+++ b/pkg/providers/property/testdata/TestResProperty/Lifecycle/rules custom diff/step0.tf
@@ -1,0 +1,22 @@
+provider "akamai" {
+  edgerc = "~/.edgerc"
+}
+
+resource "akamai_property" "test" {
+  name = "test property"
+  contract_id = "ctr_0"
+  group_id    = "grp_0"
+  product  = "prd_0"
+
+  rules = data.akamai_property_rules_template.rules.json
+
+  hostnames {
+    cname_to= "to.test.domain"
+    cname_from="from.test.domain"
+    cert_provisioning_type= "DEFAULT"
+  }
+}
+
+data "akamai_property_rules_template" "rules" {
+  template_file = "testdata/TestResProperty/Lifecycle/rules custom diff/property-snippets/rules0.json"
+}

--- a/pkg/providers/property/testdata/TestResProperty/Lifecycle/rules custom diff/step1.tf
+++ b/pkg/providers/property/testdata/TestResProperty/Lifecycle/rules custom diff/step1.tf
@@ -1,0 +1,22 @@
+provider "akamai" {
+  edgerc = "~/.edgerc"
+}
+
+resource "akamai_property" "test" {
+  name = "test property"
+  contract_id = "ctr_0"
+  group_id    = "grp_0"
+  product  = "prd_0"
+
+  rules = data.akamai_property_rules_template.rules.json
+
+  hostnames {
+    cname_to= "to.test.domain"
+    cname_from="from.test.domain"
+    cert_provisioning_type= "DEFAULT"
+  }
+}
+
+data "akamai_property_rules_template" "rules" {
+  template_file = "testdata/TestResProperty/Lifecycle/rules custom diff/property-snippets/rules1.json"
+}

--- a/pkg/tools/prefixes.go
+++ b/pkg/tools/prefixes.go
@@ -16,14 +16,6 @@ func AddPrefix(str, pre string) string {
 	return pre + str
 }
 
-// TrimPrefix will extract prefix from the given string if it is exist.
-func TrimPrefix(str, prefix string) string {
-	if strings.HasPrefix(str, prefix) {
-		return strings.TrimPrefix(str, prefix)
-	}
-	return str
-}
-
 // GetIntID is used to get the id out from the string.
 func GetIntID(str, prefix string) (int, error) {
 	return strconv.Atoi(strings.TrimPrefix(str, prefix))

--- a/pkg/tools/prefixes.go
+++ b/pkg/tools/prefixes.go
@@ -16,6 +16,14 @@ func AddPrefix(str, pre string) string {
 	return pre + str
 }
 
+// TrimPrefix will extract prefix from the given string if it is exist.
+func TrimPrefix(str, prefix string) string {
+	if strings.HasPrefix(str, prefix) {
+		return strings.TrimPrefix(str, prefix)
+	}
+	return str
+}
+
 // GetIntID is used to get the id out from the string.
 func GetIntID(str, prefix string) (int, error) {
 	return strconv.Atoi(strings.TrimPrefix(str, prefix))

--- a/pkg/tools/prefixes_test.go
+++ b/pkg/tools/prefixes_test.go
@@ -22,21 +22,6 @@ func TestAddPrefix(t *testing.T) {
 	}
 }
 
-func TestTrimPrefix(t *testing.T) {
-	tests := map[string]struct {
-		givenStr, givenPrefix, expected string
-	}{
-		"blank string":   {"", "pre_", ""},
-		"blank prefix":   {"test", "", "test"},
-		"extract prefix": {"pre_test", "pre_", "test"},
-	}
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, test.expected, TrimPrefix(test.givenStr, test.givenPrefix))
-		})
-	}
-}
-
 func TestGetIntID(t *testing.T) {
 	tests := map[string]struct {
 		givenStr, givenPrefix string

--- a/pkg/tools/prefixes_test.go
+++ b/pkg/tools/prefixes_test.go
@@ -22,6 +22,21 @@ func TestAddPrefix(t *testing.T) {
 	}
 }
 
+func TestTrimPrefix(t *testing.T) {
+	tests := map[string]struct {
+		givenStr, givenPrefix, expected string
+	}{
+		"blank string":   {"", "pre_", ""},
+		"blank prefix":   {"test", "", "test"},
+		"extract prefix": {"pre_test", "pre_", "test"},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expected, TrimPrefix(test.givenStr, test.givenPrefix))
+		})
+	}
+}
+
 func TestGetIntID(t *testing.T) {
 	tests := map[string]struct {
 		givenStr, givenPrefix string


### PR DESCRIPTION
# 1.6.1 (Jul 21, 2021)

### BUG FIXES:
* DNS
  * Fixed contract id not being set in zone import and made group optional ([#242](https://github.com/akamai/terraform-provider-akamai/issues/242))
* GTM
  * Fixed documentation mismatch with optional/required fields on nested objects for `akamai_gmt_property` resource ([#240](https://github.com/akamai/terraform-provider-akamai/issues/240))
* PAPI
  * Fixed issue with property hostnames list changing order in diff ([#230](https://github.com/akamai/terraform-provider-akamai/issues/230))
  * Fixed idempotency issue on `akamai_property` resource ([#226](https://github.com/akamai/terraform-provider-akamai/issues/226))
  * Fixed issue with terraform showing misleading diff on `rules` field in `akamai_property` ([#234](https://github.com/akamai/terraform-provider-akamai/issues/234))
* CPS
  * Added `sans` field on `akamai_cps_dv_validation` to enable resending acknowledgement on after SANS are updated 

### FEATURES/ENHANCEMENTS:
* CPS
  * `akamai_cps_dv_enrollment` now accepts `contract_id` with `ctr_` prefix