### PR TITLE
Fixing example usage for AppSec

### DIFF
--- a/docs/guides/get_started_appsec.md
+++ b/docs/guides/get_started_appsec.md
@@ -134,6 +134,7 @@ your `akamai.tf` file:
 ```hcl
 data "akamai_appsec_export_configuration" "export" {
   config_id = data.akamai_appsec_configuration.configuration.config_id
+  version = data.akamai_appsec_configuration.configuration.latest_version
   search = [
   "customRules",
   "selectedHosts"


### PR DESCRIPTION
The argument **version** is missing in the example usage. It returns the following error message.
`Error: Missing required argument
│ 
│   on akamai.tf line 18, in data "akamai_appsec_export_configuration" "export":
│   18: data "akamai_appsec_export_configuration" "export" {
│ 
│ The argument "version" is required, but no definition was found.`
