### PR TITLE
Fix argument reference for var_values_file,var_definition_file

### DIFF
--- a/docs/data-sources/property_rules_template.md
+++ b/docs/data-sources/property_rules_template.md
@@ -124,12 +124,12 @@ resource "akamai_property" "example" {
 ## Argument reference
 
 * `template_file` - (Required) The absolute path to your top-level JSON template file. The top-level template combines smaller, nested JSON templates to form your property rule tree.
-* `variables` - (Optional) A definition of a variable. Variables aren't required and you can use multiple ones if needed. This argument conflicts with the `variable_definition_file` and `variable_values_file` arguments. A `variables` block includes:
+* `variables` - (Optional) A definition of a variable. Variables aren't required and you can use multiple ones if needed. This argument conflicts with the `var_definition_file` and `var_values_file` arguments. A `variables` block includes:
     * `name` - The name of the variable used in template.
     * `type` - The type of variable: `string`, `number`, `bool`, or `jsonBlock`.
     * `value` - The value of the variable passed as a string.
-* `variable_definition_file` - (Optional) The absolute path to the file containing variable definitions and defaults. This file follows the syntax used in the [Property Manager CLI](https://github.com/akamai/cli-property-manager). This argument is required if you set `variable_values_file` and conflicts with `variables`.
-* `variable_values_file` - (Optional) The absolute path to the file containing variable values. This file follows the syntax used in the Property Manager CLI. This argument is required if you set `variable_definition_file` and conflicts with `variables`.
+* `var_definition_file` - (Optional) The absolute path to the file containing variable definitions and defaults. This file follows the syntax used in the [Property Manager CLI](https://github.com/akamai/cli-property-manager). This argument is required if you set `var_values_file` and conflicts with `variables`.
+* `var_values_file` - (Optional) The absolute path to the file containing variable values. This file follows the syntax used in the Property Manager CLI. This argument is required if you set `var_definition_file` and conflicts with `variables`.
 
 ## Attributes reference
 


### PR DESCRIPTION
Fixing the documentation for the property_rules_template datasource by referring to the actual argument names. 