### PR TITLE
DXE-399 Revert

### DIFF
--- a/pkg/providers/datastream/resource_akamai_datastream.go
+++ b/pkg/providers/datastream/resource_akamai_datastream.go
@@ -95,7 +95,7 @@ var datastreamResourceSchema = map[string]*schema.Schema{
 		Description: "The date and time when the stream was created",
 	},
 	"dataset_fields_ids": {
-		Type:     schema.TypeSet,
+		Type:     schema.TypeList,
 		Required: true,
 		Elem: &schema.Schema{
 			Type: schema.TypeInt,
@@ -637,11 +637,11 @@ func resourceDatastreamCreate(ctx context.Context, d *schema.ResourceData, m int
 	}
 	contractID = strings.TrimPrefix(contractID, "ctr_")
 
-	datasetFieldsIDsList, err := tools.GetSetValue("dataset_fields_ids", d)
+	datasetFieldsIDsList, err := tools.GetListValue("dataset_fields_ids", d)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	datasetFieldsIDs := InterfaceSliceToIntSlice(datasetFieldsIDsList.List())
+	datasetFieldsIDs := InterfaceSliceToIntSlice(datasetFieldsIDsList)
 
 	emailIDsList, err := tools.GetListValue("email_ids", d)
 	if err != nil {
@@ -931,11 +931,11 @@ func updateStream(ctx context.Context, client datastream.DS, logger log.Interfac
 			return err
 		}
 
-		datasetFieldsIDsList, err := tools.GetSetValue("dataset_fields_ids", d)
+		datasetFieldsIDsList, err := tools.GetListValue("dataset_fields_ids", d)
 		if err != nil {
 			return err
 		}
-		datasetFieldsIDs := InterfaceSliceToIntSlice(datasetFieldsIDsList.List())
+		datasetFieldsIDs := InterfaceSliceToIntSlice(datasetFieldsIDsList)
 
 		emailIDsList, err := tools.GetListValue("email_ids", d)
 		if err != nil {


### PR DESCRIPTION
Reverts akamai/terraform-provider-akamai#274

After deep analysis, we have found out that order of `dataset_fields_ids` is important. The services being called to [create](https://techdocs.akamai.com/datastream2/reference/post-stream) and [update](https://techdocs.akamai.com/datastream2/reference/put-stream) stream say it explicitly:

![image](https://user-images.githubusercontent.com/1519467/153591068-9b81452c-44e4-4662-91b3-a7e33bd60eff.png)

> The order of the identifiers define how the the values for these fields appear in the log lines.

Thus we need to revert the previous PR.

Related to https://github.com/akamai/terraform-provider-akamai/issues/263

