### PR TITLE
feat: add search data source

### DIFF
--- a/docs/data-sources/properties_search.md
+++ b/docs/data-sources/properties_search.md
@@ -1,0 +1,44 @@
+---
+layout: "akamai"
+page_title: "Akamai: akamai_properties_search"
+subcategory: "Property Provisioning"
+description: |-
+ Search
+---
+
+# akamai_properties_search
+
+
+Use the `akamai_properties_search` data source to retrieve the list of properties matching a specific hostname, edge hostname or property name based on the [EdgeGrid API client token](https://techdocs.akamai.com/developer/docs/authenticate-with-edgegrid) you're using.
+
+## Example usage
+
+Return properties associated with the EdgeGrid API client token currently used for authentication:
+
+
+```hcl
+datasource "akamai_properties_search" "example" {
+  key = "hostname"
+  value = "test.akamai.com"
+}
+
+output "my_property_list" {
+  value = data.akamai_properties_search.example
+}
+```
+
+## Argument reference
+
+This data source supports these arguments:
+
+* `key` - (Required) Key used for search. Valid values are:
+  * **hostname**
+  * **edgeHostname**
+  * **propertyName**
+* `value` - (Required) Value to search for.
+
+## Attributes reference
+
+This data source returns this attribute:
+
+* `properties` - A list of property version matching the given criteria.

--- a/pkg/providers/property/data_akamai_properties_search.go
+++ b/pkg/providers/property/data_akamai_properties_search.go
@@ -1,0 +1,115 @@
+package property
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v2/pkg/papi"
+	"github.com/akamai/terraform-provider-akamai/v2/pkg/akamai"
+	"github.com/akamai/terraform-provider-akamai/v2/pkg/tools"
+)
+
+func dataSourcePropertiesSearch() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePropertiesSearchRead,
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:             schema.TypeString,
+				Required:         true,
+				Description:      "Key must have one of three values: 'edgeHostname', 'hostname' or 'propertyName'",
+				ValidateDiagFunc: tools.ValidateStringInSlice([]string{papi.SearchKeyEdgeHostname, papi.SearchKeyHostname, papi.SearchKeyPropertyName}),
+			},
+			"value": {
+				Type:             schema.TypeString,
+				Required:         true,
+				Description:      "Value of Search",
+				ValidateDiagFunc: tools.IsNotBlank,
+			},
+			"properties": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of properties",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"account_id":        {Type: schema.TypeString, Computed: true},
+						"asset_id":          {Type: schema.TypeString, Computed: true},
+						"contract_id":       {Type: schema.TypeString, Computed: true},
+						"group_id":          {Type: schema.TypeString, Computed: true},
+						"property_id":       {Type: schema.TypeString, Computed: true},
+						"property_version":  {Type: schema.TypeInt, Computed: true},
+						"property_name":     {Type: schema.TypeString, Computed: true},
+						"edge_hostname":     {Type: schema.TypeString, Computed: true},
+						"hostname":          {Type: schema.TypeString, Computed: true},
+						"production_status": {Type: schema.TypeString, Computed: true},
+						"staging_status":    {Type: schema.TypeString, Computed: true},
+						"updated_by_user":   {Type: schema.TypeString, Computed: true},
+						"updated_date":      {Type: schema.TypeString, Computed: true},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourcePropertiesSearchRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	meta := akamai.Meta(m)
+	client := inst.Client(meta)
+
+	log := meta.Log("PAPI", "dataSourcePropertiesSearchRead")
+
+	log.Debug("Searching properties")
+
+	var key, value string
+	var err error
+
+	if key, err = tools.GetStringValue("key", d); err != nil {
+		return diag.FromErr(err)
+	}
+	if value, err = tools.GetStringValue("value", d); err != nil {
+		return diag.FromErr(err)
+	}
+
+	request := papi.SearchRequest{
+		Key:   key,
+		Value: value,
+	}
+
+	search, err := client.SearchProperties(ctx, request)
+	if err != nil {
+		return diag.Errorf("could not load properties: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s", request.Key, request.Value))
+
+	if err := d.Set("properties", sliceResponseSearch(search)); err != nil {
+		return diag.Errorf("error setting properties: %s", err)
+	}
+
+	return nil
+}
+
+func sliceResponseSearch(propertiesResponse *papi.SearchResponse) []map[string]interface{} {
+	var properties []map[string]interface{}
+	for _, item := range propertiesResponse.Versions.Items {
+		property := map[string]interface{}{
+			"account_id":        item.AccountID,
+			"asset_id":          item.AssetID,
+			"contract_id":       item.ContractID,
+			"group_id":          item.GroupID,
+			"property_id":       item.PropertyID,
+			"property_version":  item.PropertyVersion,
+			"property_name":     item.PropertyName,
+			"edge_hostname":     item.EdgeHostname,
+			"hostname":          item.Hostname,
+			"production_status": item.ProductionStatus,
+			"staging_status":    item.StagingStatus,
+			"updated_by_user":   item.UpdatedByUser,
+			"updated_date":      item.UpdatedDate,
+		}
+		properties = append(properties, property)
+	}
+	return properties
+}

--- a/pkg/providers/property/data_akamai_properties_search_test.go
+++ b/pkg/providers/property/data_akamai_properties_search_test.go
@@ -1,0 +1,108 @@
+package property
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v2/pkg/papi"
+)
+
+func TestDSPropertiesSearch(t *testing.T) {
+	t.Run("match by hostname", func(t *testing.T) {
+		client := &mockpapi{}
+
+		search := papi.SearchItems{Items: []papi.SearchItem{
+			{
+				AccountID:        "acc_test",
+				AssetID:          "aid_test",
+				GroupID:          "grp_test",
+				ContractID:       "ctr_test",
+				EdgeHostname:     "www.example.com.edgekey.net",
+				Hostname:         "www.example.com",
+				ProductionStatus: "INACTIVE",
+				StagingStatus:    "ACTIVE",
+				PropertyID:       "prp_test",
+				PropertyName:     "test_www.example.com",
+				PropertyVersion:  1,
+				UpdatedByUser:    "test_user@example.com",
+				UpdatedDate:      "2021-11-22T07:24:56Z",
+			},
+			{
+				AccountID:        "acc_test",
+				AssetID:          "aid_test",
+				GroupID:          "grp_test",
+				ContractID:       "ctr_test",
+				EdgeHostname:     "www.example.com.edgekey.net",
+				Hostname:         "www.example.com",
+				ProductionStatus: "ACTIVE",
+				StagingStatus:    "INACTIVE",
+				PropertyID:       "prp_test1",
+				PropertyName:     "test1_www.example.com",
+				PropertyVersion:  1,
+				UpdatedByUser:    "test_user@example.com",
+				UpdatedDate:      "2021-11-22T07:24:56Z",
+			},
+		}}
+
+		client.On("SearchProperties",
+			mock.Anything, // ctx is irrelevant for this test
+			papi.SearchRequest{Key: "hostname", Value: "www.example.com"},
+		).Return(&papi.SearchResponse{Versions: search}, nil)
+
+		useClient(client, func() {
+			resource.UnitTest(t, resource.TestCase{
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{{
+					Config: loadFixtureString("testdata/TestDSPropertiesSearch/match_by_hostname.tf"),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("data.akamai_properties_search.test", "id", "hostname:www.example.com"),
+						resource.TestCheckResourceAttr("data.akamai_properties_search.test", "properties.#", "2"),
+						resource.TestCheckResourceAttr("data.akamai_properties_search.test", "properties.0.account_id", "acc_test"),
+						resource.TestCheckResourceAttr("data.akamai_properties_search.test", "properties.0.asset_id", "aid_test"),
+						resource.TestCheckResourceAttr("data.akamai_properties_search.test", "properties.0.contract_id", "ctr_test"),
+						resource.TestCheckResourceAttr("data.akamai_properties_search.test", "properties.0.group_id", "grp_test"),
+						resource.TestCheckResourceAttr("data.akamai_properties_search.test", "properties.0.property_id", "prp_test"),
+						resource.TestCheckResourceAttr("data.akamai_properties_search.test", "properties.1.property_id", "prp_test1"),
+						resource.TestCheckResourceAttr("data.akamai_properties_search.test", "properties.0.property_version", "1"),
+						resource.TestCheckResourceAttr("data.akamai_properties_search.test", "properties.0.property_name", "test_www.example.com"),
+						resource.TestCheckResourceAttr("data.akamai_properties_search.test", "properties.1.property_name", "test1_www.example.com"),
+						resource.TestCheckResourceAttr("data.akamai_properties_search.test", "properties.0.edge_hostname", "www.example.com.edgekey.net"),
+						resource.TestCheckResourceAttr("data.akamai_properties_search.test", "properties.0.hostname", "www.example.com"),
+						resource.TestCheckResourceAttr("data.akamai_properties_search.test", "properties.0.production_status", "INACTIVE"),
+						resource.TestCheckResourceAttr("data.akamai_properties_search.test", "properties.1.production_status", "ACTIVE"),
+						resource.TestCheckResourceAttr("data.akamai_properties_search.test", "properties.0.staging_status", "ACTIVE"),
+						resource.TestCheckResourceAttr("data.akamai_properties_search.test", "properties.1.staging_status", "INACTIVE"),
+						resource.TestCheckResourceAttr("data.akamai_properties_search.test", "properties.0.updated_by_user", "test_user@example.com"),
+						resource.TestCheckResourceAttr("data.akamai_properties_search.test", "properties.0.updated_date", "2021-11-22T07:24:56Z"),
+					),
+				}},
+			})
+		})
+
+		client.AssertExpectations(t)
+	})
+
+	t.Run("search error", func(t *testing.T) {
+		client := &mockpapi{}
+
+		client.On("SearchProperties",
+			mock.Anything, // ctx is irrelevant for this test
+			papi.SearchRequest{Key: "hostname", Value: "www.example.com"},
+		).Return(nil, papi.ErrSearchProperties)
+
+		useClient(client, func() {
+			resource.UnitTest(t, resource.TestCase{
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{{
+					Config:      loadFixtureString("testdata/TestDSPropertiesSearch/match_by_hostname.tf"),
+					ExpectError: regexp.MustCompile("searching for properties"),
+				}},
+			})
+		})
+
+		client.AssertExpectations(t)
+	})
+}

--- a/pkg/providers/property/provider.go
+++ b/pkg/providers/property/provider.go
@@ -84,6 +84,7 @@ func Provider() *schema.Provider {
 			"akamai_properties":              dataSourceAkamaiProperties(),
 			"akamai_property_products":       dataSourceAkamaiPropertyProducts(),
 			"akamai_property_hostnames":      dataSourceAkamaiPropertyHostnames(),
+			"akamai_properties_search":       dataSourcePropertiesSearch(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"akamai_cp_code":             resourceCPCode(),

--- a/pkg/providers/property/testdata/TestDSPropertiesSearch/match_by_hostname.tf
+++ b/pkg/providers/property/testdata/TestDSPropertiesSearch/match_by_hostname.tf
@@ -1,0 +1,8 @@
+provider "akamai" {
+  edgerc = "~/.edgerc"
+}
+
+data "akamai_properties_search" "test" {
+  key   = "hostname"
+  value = "www.example.com"
+}


### PR DESCRIPTION
This is to add data source for search.
Right now to have a list of properties using a specific hostname can be done only by looping over all the properties.
This could lead to a great number sequential of API calls.

This new data source can ease the search of properties that match a specific hostname or edge hostname