### PR TITLE
Set DNSNameSettings in enrollment only for SNI certs

### DIFF
--- a/pkg/providers/cps/tools/enrollment.go
+++ b/pkg/providers/cps/tools/enrollment.go
@@ -143,9 +143,11 @@ func GetNetworkConfig(d *schema.ResourceData) (*cps.NetworkConfiguration, error)
 	for _, val := range sansList.List() {
 		dnsNames = append(dnsNames, val.(string))
 	}
-	networkConfig.DNSNameSettings = &cps.DNSNameSettings{
-		CloneDNSNames: networkConfigMap["clone_dns_names"].(bool),
-		DNSNames:      dnsNames,
+	if sniOnly {
+		networkConfig.DNSNameSettings = &cps.DNSNameSettings{
+			CloneDNSNames: networkConfigMap["clone_dns_names"].(bool),
+			DNSNames:      dnsNames,
+		}
 	}
 	networkConfig.OCSPStapling = cps.OCSPStapling(networkConfigMap["ocsp_stapling"].(string))
 	disallowedTLSVersionsSet := networkConfigMap["disallowed_tls_versions"].(*schema.Set)


### PR DESCRIPTION
This PR provides a simple fix for VIP certificate enrollment provisioning.

The DNSNameSettings hash must not be included in the request for VIP certificates.
Such requests are rejected by the CPS API.

For completeness, there may be other changes necessary in the code.
However, I am not that deep into provider internals, hence I went with this simple fix to make things work for now.
