### PR TITLE
DXE-591 upgrade goreleaser go-version to 1.17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.17
       - name: Import GPG key
         id: import_gpg
         uses: paultyng/ghaction-import-gpg@v2.1.0


### PR DESCRIPTION
fix for https://github.com/akamai/terraform-provider-akamai/runs/5405319586