### PR TITLE
DXE-739 remove from build windows_arm64 and darwin_arm64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,6 +29,10 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
+    - goos: darwin
+      goarch: 'arm64'
+    - goos: windows
+      goarch: 'arm64'
 #    - goos: freebsd
 #      goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'


### PR DESCRIPTION
## 1.12.1 (Apr 1, 2022)

#### BUG FIXES:

* Add metadata required by terraform registry