### PR TITLE
Enabling build for darwin arm64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,8 +29,6 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
-    - goos: darwin
-      goarch: 'arm64'
     - goos: windows
       goarch: 'arm64'
 #    - goos: freebsd


### PR DESCRIPTION
- Enabling build on darwin arm64 as discussed on #236 with capability now supported in goreleaser
- goreleaser now supports it and this seemed like the previous limitation to have it ignored

_please excuse my naivety if the change is much bigger than this, from my brief look and understanding, it seemed like the primary limitation in the past was go and goreleaser support which is now resolved_