### PR TITLE
SECKSD-16233 feature/network_lists sync point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # RELEASE NOTES
 
+## 2.2.1 (TBD)
+
+#### FEATURES/ENHANCEMENTS:
+
+* NETWORK LISTS
+  * Include sync_point in akamai_networklist_network_lists resource
+
 ## 2.2.0 (June 30, 2022)
 
 #### FEATURES/ENHANCEMENTS:

--- a/docs/resources/networklist_activations.md
+++ b/docs/resources/networklist_activations.md
@@ -27,6 +27,7 @@ data "akamai_networklist_network_lists" "network_lists_filter" {
 resource "akamai_networklist_activations" "activation" {
   network_list_id = data.akamai_networklist_network_lists.network_lists_filter.list[0]
   network = "STAGING"
+  sync_point = data.akamai_networklist_network_lists.network_lists_filter.list[0].sync_point
   notes  = "TEST Notes"
   notification_emails = ["user@example.com"]
 }
@@ -40,7 +41,10 @@ The following arguments are supported:
 
 * `network` - (Optional) The network to be used, either `STAGING` or `PRODUCTION`. If not supplied, defaults to
   `STAGING`.
-
+  
+* `network` - (Optional) The sync_point allows for automatic activation of a network list. If not supplied, defaults to
+  `0`. Forces a new activation request if changed.
+  
 * `notes` - (Optional) A comment describing the activation.
 
 * `notification_emails` - (Required) A bracketed, comma-separated list of email addresses that will be notified when the

--- a/docs/resources/networklist_activations.md
+++ b/docs/resources/networklist_activations.md
@@ -42,7 +42,7 @@ The following arguments are supported:
 * `network` - (Optional) The network to be used, either `STAGING` or `PRODUCTION`. If not supplied, defaults to
   `STAGING`.
   
-* `network` - (Optional) The sync_point allows for automatic activation of a network list. If not supplied, defaults to
+* `sync_point` - (Optional) The sync_point allows for automatic activation of a network list. If not supplied, defaults to
   `0`. Forces a new activation request if changed.
   
 * `notes` - (Optional) A comment describing the activation.

--- a/pkg/providers/networklists/resource_akamai_networklist_activations.go
+++ b/pkg/providers/networklists/resource_akamai_networklist_activations.go
@@ -39,6 +39,12 @@ func resourceActivations() *schema.Resource {
 				Optional: true,
 				Default:  "STAGING",
 			},
+			"sync_point": {
+                Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+                ForceNew: true,
+            },
 			"notes": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/pkg/providers/networklists/resource_akamai_networklist_activations.go
+++ b/pkg/providers/networklists/resource_akamai_networklist_activations.go
@@ -40,10 +40,10 @@ func resourceActivations() *schema.Resource {
 				Default:  "STAGING",
 			},
 			"sync_point": {
-                Type:     schema.TypeInt,
+				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  0,
-                ForceNew: true,
+				ForceNew: true,
             },
 			"notes": {
 				Type:     schema.TypeString,

--- a/pkg/providers/networklists/resource_akamai_networklist_activations.go
+++ b/pkg/providers/networklists/resource_akamai_networklist_activations.go
@@ -44,7 +44,7 @@ func resourceActivations() *schema.Resource {
 				Optional: true,
 				Default:  0,
 				ForceNew: true,
-            },
+			},
 			"notes": {
 				Type:     schema.TypeString,
 				Optional: true,


### PR DESCRIPTION
This change allows activation each time an existing network_list changes; this improves CI/CD process for managing network lists and activating in either STAGING and/or PRODUCTION automatically and optionally


```
resource "akamai_networklist_activations" "activation" {
 network_list_id     = akamai_networklist_network_list.network_list.network_list_id
 network             = "STAGING"
 sync_point       = akamai_networklist_network_list.network_list.sync_point
 notes               = "This is the staged network for the documentation test network."
 notification_emails = ["gstemp@akamai.com"]

 depends_on = [ akamai_networklist_network_list.network_list ]
}
```
