### PR TITLE
DXE-2298 allocate array of datastream fields size

### DIFF
--- a/pkg/providers/datastream/stream.go
+++ b/pkg/providers/datastream/stream.go
@@ -106,7 +106,6 @@ func InterfaceSliceToStringSlice(list []interface{}) []string {
 
 // DataSetFieldsToList converts slice of DataSets to slice of ints
 func DataSetFieldsToList(dataSets []datastream.DataSets) []int {
-	ids := make([]int, 0)
 	datasetFields := make([]datastream.DatasetFields, 0)
 
 	for _, datasetGroup := range dataSets {
@@ -116,6 +115,8 @@ func DataSetFieldsToList(dataSets []datastream.DataSets) []int {
 	sort.Slice(datasetFields, func(i, j int) bool {
 		return datasetFields[i].Order < datasetFields[j].Order
 	})
+
+	ids := make([]int, 0, len(datasetFields))
 
 	for _, field := range datasetFields {
 		ids = append(ids, field.DatasetFieldID)


### PR DESCRIPTION
The previous PR: https://github.com/akamai/terraform-provider-akamai/pull/333 was closed. 

I reviewed the unit tests and there's nothing to add up. The changes are covered by https://github.com/akamai/terraform-provider-akamai/blob/master/pkg/providers/datastream/stream_test.go#L206