### PR TITLE
DXE-2295 bug: property_rules_template data source fails with multiple includes in array

### DIFF
--- a/pkg/providers/property/data_akamai_property_rules_template.go
+++ b/pkg/providers/property/data_akamai_property_rules_template.go
@@ -266,8 +266,8 @@ func dataPropertyRulesTemplateRead(_ context.Context, d *schema.ResourceData, m 
 }
 
 var (
-	includeRegexp  = regexp.MustCompile(`"#include:.+"`)
-	varRegexp      = regexp.MustCompile(`"\${.+}"`)
+	includeRegexp  = regexp.MustCompile(`"#include:.+?"`)
+	varRegexp      = regexp.MustCompile(`"\${.+?}"`)
 	jsonFileRegexp = regexp.MustCompile(`\.json+$`)
 )
 

--- a/pkg/providers/property/data_akamai_property_rules_template_test.go
+++ b/pkg/providers/property/data_akamai_property_rules_template_test.go
@@ -600,6 +600,10 @@ func TestStringToTemplate(t *testing.T) {
 			givenFile:    "template_in.json",
 			expectedFile: "template_out.json",
 		},
+		"multiple includes in array": {
+			givenFile:    "template_in_with_array.json",
+			expectedFile: "template_out_with_array.json",
+		},
 		"plain JSON passed": {
 			givenFile:    "plain_json.json",
 			expectedFile: "plain_json.json",

--- a/pkg/providers/property/data_akamai_property_rules_template_test.go
+++ b/pkg/providers/property/data_akamai_property_rules_template_test.go
@@ -116,7 +116,7 @@ func TestDataAkamaiPropertyRulesRead(t *testing.T) {
 			})
 		})
 	})
-	t.Run("error setting both ,ap and file variables", func(t *testing.T) {
+	t.Run("error setting both map and file variables", func(t *testing.T) {
 		client := papi.Mock{}
 		useClient(&client, nil, func() {
 			resource.UnitTest(t, resource.TestCase{

--- a/pkg/providers/property/testdata/TestDSRulesTemplate/output/template_out.json
+++ b/pkg/providers/property/testdata/TestDSRulesTemplate/output/template_out.json
@@ -1,8 +1,6 @@
 {
   "rules": {
     "name": @+#.name#+@,
-    "children": [
-      @+#template "snippets/some-template.json" .#+@
-    ]
+    "children": [@+#template "snippets/some-template.json" .#+@, @+#template "snippets/some-template.json" .#+@]
   }
 }

--- a/pkg/providers/property/testdata/TestDSRulesTemplate/output/template_out.json
+++ b/pkg/providers/property/testdata/TestDSRulesTemplate/output/template_out.json
@@ -1,6 +1,6 @@
 {
   "rules": {
     "name": @+#.name#+@,
-    "children": [@+#template "snippets/some-template.json" .#+@, @+#template "snippets/some-template.json" .#+@]
+    "children": [@+#template "snippets/some-template.json" .#+@]
   }
 }

--- a/pkg/providers/property/testdata/TestDSRulesTemplate/output/template_out_with_array.json
+++ b/pkg/providers/property/testdata/TestDSRulesTemplate/output/template_out_with_array.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "name": @+#.name#+@,
+    "children": [@+#template "snippets/some-template.json" .#+@, @+#template "snippets/some-template.json" .#+@]
+  }
+}

--- a/pkg/providers/property/testdata/TestDSRulesTemplate/rules/property-snippets/template_in.json
+++ b/pkg/providers/property/testdata/TestDSRulesTemplate/rules/property-snippets/template_in.json
@@ -1,8 +1,6 @@
 {
   "rules": {
     "name": "${env.name}",
-    "children": [
-      "#include:snippets/some-template.json"
-    ]
+    "children": ["#include:snippets/some-template.json", "#include:snippets/some-template.json"]
   }
 }

--- a/pkg/providers/property/testdata/TestDSRulesTemplate/rules/property-snippets/template_in.json
+++ b/pkg/providers/property/testdata/TestDSRulesTemplate/rules/property-snippets/template_in.json
@@ -1,6 +1,6 @@
 {
   "rules": {
     "name": "${env.name}",
-    "children": ["#include:snippets/some-template.json", "#include:snippets/some-template.json"]
+    "children": ["#include:snippets/some-template.json"]
   }
 }

--- a/pkg/providers/property/testdata/TestDSRulesTemplate/rules/property-snippets/template_in_with_array.json
+++ b/pkg/providers/property/testdata/TestDSRulesTemplate/rules/property-snippets/template_in_with_array.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "name": "${env.name}",
+    "children": ["#include:snippets/some-template.json", "#include:snippets/some-template.json"]
+  }
+}


### PR DESCRIPTION
## what

- Update the regex expressions that match `#include` and variable templates in the `property_rules_template` data source.
- Update the `TestDSRulesTemplate` test data to test for multiple instances within a JSON array

## why

The previous regex was greedy and would match multiple `#include` or variables in an array as a single match resulting in invalid json.

Given the following:

```json
{
"behaviors: ["#include:foo.json", "#include:match.json"]
"foo: ["${env.foo}", "${env.bar}"]
}
```

The original regex produces:

![CleanShot 2023-02-07 at 20 59 51](https://user-images.githubusercontent.com/930247/217409432-6854c2c7-8619-4213-a619-d5311db404a9.png)

![CleanShot 2023-02-07 at 20 58 16](https://user-images.githubusercontent.com/930247/217409242-b90e8169-007e-4f79-aade-b4ff23388d13.png)

While the updated regex correctly produces:

![CleanShot 2023-02-07 at 21 00 15](https://user-images.githubusercontent.com/930247/217409482-cbed70ae-6759-455d-ad79-8dd3f76f8480.png)

![CleanShot 2023-02-07 at 20 59 05](https://user-images.githubusercontent.com/930247/217409327-e0844fdc-331f-49da-89e9-6bd889eadb76.png)

## test output

```
go test ./... -v -count=1 -run TestStringToTemplate
?   	github.com/akamai/terraform-provider-akamai/v3	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/akamai/terraform-provider-akamai/v3/pkg/akamai	0.392s [no tests to run]
?   	github.com/akamai/terraform-provider-akamai/v3/pkg/config	[no test files]
?   	github.com/akamai/terraform-provider-akamai/v3/pkg/providers	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/akamai/terraform-provider-akamai/v3/pkg/providers/appsec	0.300s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/akamai/terraform-provider-akamai/v3/pkg/providers/botman	0.596s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/akamai/terraform-provider-akamai/v3/pkg/providers/cloudlets	0.494s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/akamai/terraform-provider-akamai/v3/pkg/providers/cps	0.190s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/akamai/terraform-provider-akamai/v3/pkg/providers/cps/tools	0.137s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/akamai/terraform-provider-akamai/v3/pkg/providers/datastream	0.724s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/akamai/terraform-provider-akamai/v3/pkg/providers/dns	0.790s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/akamai/terraform-provider-akamai/v3/pkg/providers/edgeworkers	0.870s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/akamai/terraform-provider-akamai/v3/pkg/providers/gtm	0.819s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/akamai/terraform-provider-akamai/v3/pkg/providers/iam	0.885s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/akamai/terraform-provider-akamai/v3/pkg/providers/imaging	0.841s [no tests to run]
?   	github.com/akamai/terraform-provider-akamai/v3/pkg/providers/imaging/imagewriter	[no test files]
?   	github.com/akamai/terraform-provider-akamai/v3/pkg/providers/imaging/videowriter	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/akamai/terraform-provider-akamai/v3/pkg/providers/networklists	0.831s [no tests to run]
=== RUN   TestStringToTemplate
=== RUN   TestStringToTemplate/valid_conversion
{
  "rules": {
    "name": @+#.name#+@,
    "children": [@+#template "snippets/some-template.json" .#+@, @+#template "snippets/some-template.json" .#+@]
  }
}

=== RUN   TestStringToTemplate/plain_JSON_passed
{
  "rules": {
    "name": "test",
    "children": [
      {
        "name": "RUM",
        "children": [
        ],
        "behaviors": [
          {
            "name": "mPulse",
            "options": {
              "enabled": true,
              "requirePci": false,
              "titleOptional": "",
              "apiKey": "",
              "bufferSize": "",
              "configOverride": ""
            }
          }
        ],
        "criteria": [],
        "criteriaMustSatisfy": "all"
      }
    ]
  }
}

--- PASS: TestStringToTemplate (0.00s)
    --- PASS: TestStringToTemplate/valid_conversion (0.00s)
    --- PASS: TestStringToTemplate/plain_JSON_passed (0.00s)
PASS
ok  	github.com/akamai/terraform-provider-akamai/v3/pkg/providers/property	0.828s
?   	github.com/akamai/terraform-provider-akamai/v3/pkg/providers/registry	[no test files]
?   	github.com/akamai/terraform-provider-akamai/v3/pkg/test	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/akamai/terraform-provider-akamai/v3/pkg/tools	0.760s [no tests to run]
?   	github.com/akamai/terraform-provider-akamai/v3/version	[no test files]
go test ./... -v -count=1 -run TestStringToTemplate  9.40s user 1.98s system 395% cpu 2.875 total
```

## references

Closes #386 