### PR TITLE
DXE-2234 Added release notes into draft release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@
 # Uncomment the event for tag push to have it execute when a new tag is published. 
 # You may want to constrain events to tags that match valid semver patterns.
 #
-# This uses an action (paultyng/ghaction-import-gpg) that assumes you set your 
+# This uses an action (crazy-max/ghaction-import-gpg@v5) that assumes you set your
 # private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
 # secret. If you would rather own your own GPG handling, please fork this action
 # or use an alternative one for key handling.
@@ -29,10 +29,15 @@ jobs:
           go-version: 1.18
       - name: Import GPG key
         id: import_gpg
-        uses: paultyng/ghaction-import-gpg@v2.1.0
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+        uses: crazy-max/ghaction-import-gpg@v5
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
+      - name: Get changelog
+        run: |
+          echo 'CHANGELOG_BODY<<EOF' >> $GITHUB_ENV
+          awk '/## ([0-9]+\.?)+/{n++}; n==1; n==2{exit}' CHANGELOG.md >> $GITHUB_ENV
+          echo 'EOF'>> $GITHUB_ENV
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -41,3 +46,4 @@ jobs:
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHANGELOG_BODY: ${{ env.CHANGELOG_BODY }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,9 +53,15 @@ signs:
       - "${signature}"
       - "--detach-sign"
       - "${artifact}"
+changelog:
+  skip: true
 release:
   # Visit your project's GitHub Releases page to publish this release.
   draft: true
+  header: |
+    # RELEASE NOTES
+  footer: |
+    {{ .Env.CHANGELOG_BODY }}
   extra_files:
     - glob: 'terraform-provider-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'


### PR DESCRIPTION
The scope of this pr:
- Added release notes into draft release from the last CHANGELOG.md entry
- Updated import GPG key action since there is an issue in main repository and their recommendation is to use fork. All the information is here https://github.com/hashicorp/ghaction-import-gpg. Issue which I've got with old action https://github.com/Slonimskaia/terraform-tslonims/actions/runs/4202444315/jobs/7290594888

Tests of this new goreleaser workflow has been done on a fork here https://github.com/Slonimskaia/terraform-tslonims/releases