### PR TITLE
Bugfix get csr from long history

### DIFF
--- a/pkg/providers/cps/data_akamai_cps_csr.go
+++ b/pkg/providers/cps/data_akamai_cps_csr.go
@@ -137,17 +137,17 @@ func createCSRAttrsFromHistory(ctx context.Context, client cps.CPS, enrollmentID
 	}
 	if len(history.Changes) != 0 {
 		for _, change := range history.Changes {
-			csr_present := false
+			certificateFound := false
 			for _, cert := range append(change.MultiStackedCertificates, change.PrimaryCertificate) {
 				if cert.KeyAlgorithm == "ECDSA" {
 					attrs["csr_ecdsa"] = cert.CSR
-					csr_present = true
+					certificateFound = true
 				} else if cert.KeyAlgorithm == "RSA" {
 					attrs["csr_rsa"] = cert.CSR
-					csr_present = true
+					certificateFound = true
 				}
 			}
-			if csr_present {
+			if certificateFound {
 				break
 			}
 		}

--- a/pkg/providers/cps/data_akamai_cps_csr.go
+++ b/pkg/providers/cps/data_akamai_cps_csr.go
@@ -136,11 +136,19 @@ func createCSRAttrsFromHistory(ctx context.Context, client cps.CPS, enrollmentID
 		return nil, err
 	}
 	if len(history.Changes) != 0 {
-		for _, cert := range append(history.Changes[0].MultiStackedCertificates, history.Changes[0].PrimaryCertificate) {
-			if cert.KeyAlgorithm == "ECDSA" {
-				attrs["csr_ecdsa"] = cert.CSR
-			} else if cert.KeyAlgorithm == "RSA" {
-				attrs["csr_rsa"] = cert.CSR
+		for _, change := range history.Changes {
+			csr_present := false
+			for _, cert := range append(change.MultiStackedCertificates, change.PrimaryCertificate) {
+				if cert.KeyAlgorithm == "ECDSA" {
+					attrs["csr_ecdsa"] = cert.CSR
+					csr_present = true
+				} else if cert.KeyAlgorithm == "RSA" {
+					attrs["csr_rsa"] = cert.CSR
+					csr_present = true
+				}
+			}
+			if csr_present {
+				continue
 			}
 		}
 	}

--- a/pkg/providers/cps/data_akamai_cps_csr.go
+++ b/pkg/providers/cps/data_akamai_cps_csr.go
@@ -148,7 +148,7 @@ func createCSRAttrsFromHistory(ctx context.Context, client cps.CPS, enrollmentID
 				}
 			}
 			if csr_present {
-				continue
+				break
 			}
 		}
 	}

--- a/pkg/providers/cps/data_akamai_cps_csr_test.go
+++ b/pkg/providers/cps/data_akamai_cps_csr_test.go
@@ -476,7 +476,7 @@ func checkAttrsForCPSCSRFromHistory(data testDataForCPSCSR) resource.TestCheckFu
 			}
 		}
 		if certificate_found {
-			continue
+			break
 		}
 	}
 	if !rsa {

--- a/pkg/providers/cps/data_akamai_cps_csr_test.go
+++ b/pkg/providers/cps/data_akamai_cps_csr_test.go
@@ -457,7 +457,7 @@ func TestDataCPSCSR(t *testing.T) {
 func checkAttrsForCPSCSRFromHistory(data testDataForCPSCSR) resource.TestCheckFunc {
 	var checkFuncs []resource.TestCheckFunc
 	var rsa, ecdsa bool
-	certificate_found := false
+	certificateFound := false
 	for _, change := range data.GetChangeHistoryResponse.Changes {
 		for _, certificate := range append(change.MultiStackedCertificates, change.PrimaryCertificate) {
 			switch certificate.KeyAlgorithm {
@@ -465,17 +465,17 @@ func checkAttrsForCPSCSRFromHistory(data testDataForCPSCSR) resource.TestCheckFu
 				{
 					rsa = true
 					checkFuncs = append(checkFuncs, resource.TestCheckResourceAttr("data.akamai_cps_csr.test", "csr_rsa", certificate.CSR))
-					certificate_found = true
+					certificateFound = true
 				}
 			case "ECDSA":
 				{
 					ecdsa = true
 					checkFuncs = append(checkFuncs, resource.TestCheckResourceAttr("data.akamai_cps_csr.test", "csr_ecdsa", certificate.CSR))
-					certificate_found = true
+					certificateFound = true
 				}
 			}
 		}
-		if certificate_found {
+		if certificateFound {
 			break
 		}
 	}


### PR DESCRIPTION
closes #402 

* Add failing test case `bothAlgorithmsDataWithGetLongerChangeHistory` with change history that does not contain any certificates.  Add iteration through the `expect` functions
* Iterate through changes until a change containing certificates is found.