### PR TITLE
DXE-3087 Adds pending_changes computed field to Enrollment data source

### DIFF
--- a/pkg/providers/cps/data_akamai_cps_enrollment.go
+++ b/pkg/providers/cps/data_akamai_cps_enrollment.go
@@ -248,6 +248,11 @@ func dataSourceCPSEnrollment() *schema.Resource {
 				Computed:    true,
 				Description: "The registration authority or certificate authority (CA) used to obtain a certificate",
 			},
+			"pending_changes": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether some changes are pending",
+			},
 			"dns_challenges": {
 				Type:        schema.TypeSet,
 				Computed:    true,
@@ -323,6 +328,8 @@ func dataCPSEnrollmentRead(ctx context.Context, d *schema.ResourceData, m interf
 	}
 
 	attrs := createAttrs(enrollment, enrollmentID)
+
+	attrs["pending_changes"] = len(enrollment.PendingChanges) > 0
 
 	if err = tf.SetAttrs(d, attrs); err != nil {
 		return diag.FromErr(err)

--- a/pkg/providers/cps/data_akamai_cps_enrollment_test.go
+++ b/pkg/providers/cps/data_akamai_cps_enrollment_test.go
@@ -640,10 +640,9 @@ func checkChallenges(changes *cps.Change, dvArray *cps.DVArray) resource.TestChe
 
 func checkPendingChangesEnrollment(en *cps.Enrollment) resource.TestCheckFunc {
 	if len(en.PendingChanges) > 0 {
-		return resource.TestCheckResourceAttr("data.akamai_cps_enrollment.test", "enrollment.pending_changes", "true")
+		return resource.TestCheckResourceAttr("data.akamai_cps_enrollment.test", "pending_changes", "true")
 	}
-
-	return resource.TestCheckResourceAttr("data.akamai_cps_enrollment.test", "enrollment.pending_changes", "false")
+	return resource.TestCheckResourceAttr("data.akamai_cps_enrollment.test", "pending_changes", "false")
 }
 
 func calculateNumberOfChanges(dvArray *cps.DVArray, changeType string) int {

--- a/pkg/providers/cps/data_akamai_cps_enrollment_test.go
+++ b/pkg/providers/cps/data_akamai_cps_enrollment_test.go
@@ -500,6 +500,7 @@ func checkAttributesForEnrollment(en *cps.Enrollment, enID int, changes *cps.Cha
 		checkCommonAttrs(en, enID),
 		checkSetTypeAttrs(en),
 		checkChallenges(changes, dvArray),
+		checkPendingChangesEnrollment(en),
 	)
 }
 
@@ -635,6 +636,14 @@ func checkChallenges(changes *cps.Change, dvArray *cps.DVArray) resource.TestChe
 		}
 	}
 	return resource.ComposeAggregateTestCheckFunc(checkFunctions...)
+}
+
+func checkPendingChangesEnrollment(en *cps.Enrollment) resource.TestCheckFunc {
+	if len(en.PendingChanges) > 0 {
+		return resource.TestCheckResourceAttr("data.akamai_cps_enrollment.test", "enrollment.pending_changes", "true")
+	}
+
+	return resource.TestCheckResourceAttr("data.akamai_cps_enrollment.test", "enrollment.pending_changes", "false")
 }
 
 func calculateNumberOfChanges(dvArray *cps.DVArray, changeType string) int {


### PR DESCRIPTION
Enrollments (plural) data source returns instances with a computed field of "pending_changes". This field is missing from the individual Enrollment data source. This PR adds the missing field to the individual Enrollment data source.