### PR TITLE
DXISSUE-2794 update doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ To automatically install the Akamai Provider, run `terraform init` on a configur
 
 ## Documentation
 
-You can find documentation for the Akamai Provider on the [Terraform Website](https://registry.terraform.io/providers/akamai/akamai/latest/docs).
+You can find documentation for the Akamai Provider on the [Terraform Website](https://techdocs.akamai.com/terraform/docs/overview).


### PR DESCRIPTION
Problem: Documentation link on main README takes users to the wrong location.

Solution: Update the link to our current documentation location.