### PR TITLE
DXE-3474 correcting documentation with correct option name

### DIFF
--- a/pkg/providers/cps/enrollments.go
+++ b/pkg/providers/cps/enrollments.go
@@ -450,7 +450,7 @@ func waitForVerification(ctx context.Context, logger log.Interface, client cps.C
 
 				// for DV autoApproveWarnings is always empty
 				if !acknowledgeWarnings && len(autoApproveWarnings) == 0 {
-					return fmt.Errorf("enrollment pre-verification returned warnings and the enrollment cannot be validated. Please fix the issues or set acknowledge_pre_validation_warnings flag to true then run 'terraform apply' again: %s",
+					return fmt.Errorf("enrollment pre-verification returned warnings and the enrollment cannot be validated. Please fix the issues or set acknowledge_pre_verification_warnings flag to true then run 'terraform apply' again: %s",
 						warnings.Warnings)
 				}
 

--- a/pkg/providers/cps/resource_akamai_cps_dv_enrollment_test.go
+++ b/pkg/providers/cps/resource_akamai_cps_dv_enrollment_test.go
@@ -1765,7 +1765,7 @@ func TestResourceDVEnrollment(t *testing.T) {
 				Steps: []resource.TestStep{
 					{
 						Config:      testutils.LoadFixtureString(t, "testdata/TestResDVEnrollment/no_acknowledge_warnings/create_enrollment.tf"),
-						ExpectError: regexp.MustCompile(`enrollment pre-verification returned warnings and the enrollment cannot be validated. Please fix the issues or set acknowledge_pre_validation_warnings flag to true then run 'terraform apply' again: some warning`),
+						ExpectError: regexp.MustCompile(`enrollment pre-verification returned warnings and the enrollment cannot be validated. Please fix the issues or set acknowledge_pre_verification_warnings flag to true then run 'terraform apply' again: some warning`),
 					},
 				},
 			})

--- a/pkg/providers/cps/resource_akamai_cps_third_party_enrollment_test.go
+++ b/pkg/providers/cps/resource_akamai_cps_third_party_enrollment_test.go
@@ -1101,7 +1101,7 @@ func TestResourceThirdPartyEnrollment(t *testing.T) {
 				Steps: []resource.TestStep{
 					{
 						Config:      testutils.LoadFixtureString(t, "testdata/TestResThirdPartyEnrollment/no_acknowledge_warnings/create_enrollment.tf"),
-						ExpectError: regexp.MustCompile(`enrollment pre-verification returned warnings and the enrollment cannot be validated. Please fix the issues or set acknowledge_pre_validation_warnings flag to true then run 'terraform apply' again: some warning`),
+						ExpectError: regexp.MustCompile(`enrollment pre-verification returned warnings and the enrollment cannot be validated. Please fix the issues or set acknowledge_pre_verification_warnings flag to true then run 'terraform apply' again: some warning`),
 					},
 				},
 			})


### PR DESCRIPTION
As per:
https://github.com/akamai/terraform-provider-akamai/blob/master/pkg/providers/cps/resource_akamai_cps_third_party_enrollment.go#L67C1-L67C1

and 

https://github.com/akamai/terraform-provider-akamai/blob/6c1ab8e2d796e80767e7cffb7c488d5c97291e05/pkg/providers/cps/resource_akamai_cps_dv_enrollment.go#L68

the option name is acknowledge_pre_verification_warnings and not acknowledge_pre_validation_warnings