### PR TITLE
DXE-3461 Make organizational_unit optional

### DIFF
--- a/pkg/providers/cps/enrollments.go
+++ b/pkg/providers/cps/enrollments.go
@@ -234,7 +234,7 @@ var (
 			},
 			"organizational_unit": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "Organizational unit of organization",
 			},
 			"preferred_trust_chain": {


### PR DESCRIPTION
"organizational_unit" should be optional in order to support terraform import of already existing certs created by the UI (with not organizational_unit set).