### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
Enable Dependabot to keep used dependencies up to date.

Keeping them at current versions is a tedious task and leads to vulnerable releases. See
* https://github.com/akamai/terraform-provider-akamai/issues/522
* https://github.com/akamai/terraform-provider-akamai/issues/561