### PR TITLE
DXE-5496 Fix suppress changes issues when TXT record value/target starts with …

### DIFF
--- a/pkg/providers/dns/resource_akamai_dns_record.go
+++ b/pkg/providers/dns/resource_akamai_dns_record.go
@@ -480,7 +480,9 @@ func diffQuotedDNSRecord(oldTargetList []string, newTargetList []string, o strin
 		compList = oldTargetList
 	} else {
 		baseVal = o
-		baseVal = strings.Trim(baseVal, backslashQuote)
+		if recordType != RRTypeTxt {
+			baseVal = strings.Trim(baseVal, backslashQuote)
+		}
 		baseVal = strings.ReplaceAll(baseVal, backslashQuote, singleQuote)
 		compList = newTargetList
 	}
@@ -530,6 +532,21 @@ func diffQuotedDNSRecord(oldTargetList []string, newTargetList []string, o strin
 			compval = strings.TrimRight(compval, ".")
 			logger.Debugf("updated baseVal: %v", baseVal)
 			logger.Debugf("compval: %v", compval)
+			if baseVal == compval {
+				return true
+			}
+		}
+		return false
+	}
+
+	if recordType == RRTypeTxt {
+		for _, compval := range compList {
+			if compTrim && strings.Contains(compval, backslashQuote) {
+				compval = strings.ReplaceAll(compval, backslashQuote, singleQuote)
+			}
+			logger.Debugf("diffQuotedDNSRecord Suppress. baseVal: %v", baseVal)
+			logger.Debugf("diffQuotedDNSRecord Suppress. compval: [%v]", compval)
+			
 			if baseVal == compval {
 				return true
 			}


### PR DESCRIPTION
**Summary**
The diffQuotedDNSRecord helper, used by the dnsRecordTargetSuppress function, currently trims backslashed quotes from both old and new values before comparison. While this works for most record types, it causes incorrect behavior for TXT records, where the presence of backslashed quotes changes the meaning of the value.

**Problem**
For example, consider these two target values:

1. target = ["v=spf1 include:spf-pp.ia.ca include:spf.protection.outlook.com -all"]
2. target = ["\\"v=spf1 include:spf-pp.ia.ca include:spf.protection.outlook.com -all\\""]

If one value is in the Terraform state and you update it to the other, the current logic incorrectly reports:
`No changes. Your infrastructure matches the configuration.`

However:

- The first value results in an improperly formatted SPF record.

- The second value is a properly formatted SPF record.

**Changes Made**

1. **Prevent trimming for TXT records** – The trim operation that removes backslashed quotes is now skipped for TXT record types.
2. **TXT-specific comparison logic** – Added a TXT-specific handling block where surrounding quotes are preserved in the comparison value (compval) to ensure formatting differences are detected.

This ensures that legitimate changes to TXT record formatting, particularly for SPF records, are correctly detected and applied.