### PR TITLE
DXE-6680 Plugin Framework config: Add validator for Max Items One equivalent

### DIFF
--- a/pkg/akamai/framework_provider.go
+++ b/pkg/akamai/framework_provider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -100,6 +101,9 @@ func (p *Provider) Schema(_ context.Context, _ provider.SchemaRequest, resp *pro
 		},
 		Blocks: map[string]schema.Block{
 			"config": schema.SetNestedBlock{
+				Validators: []validator.Set{
+					setvalidator.SizeAtMost(1),
+				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"host": schema.StringAttribute{


### PR DESCRIPTION
According to https://developer.hashicorp.com/terraform/plugin/framework/migrating/attributes-blocks/blocks, when migrating the schema config block to Plugin Framework, a size validator is needed to reflect the equivalent of `MaxItems: 1` in the [corresponding SDKv2 block](https://github.com/akamai/terraform-provider-akamai/blob/9dbd942f4a48cfdb27448fe7809305ece6783453/pkg/akamai/sdk_provider.go#L38).

We discovered this downstream when consuming the Plugin Framework schema, and our model inaccurately did not flatten the config block.

Thank you for considering this pull request!

https://github.com/pulumi/pulumi-akamai/issues/825

